### PR TITLE
Optimize ``RemoveAll`` and ``SpanCopyExtensions`` for performance

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.9" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.104" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.123" />
     <PackageVersion Include="Polyfill" Version="10.11.2" />
     <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />

--- a/DotExtensions.Memory/Spans/SpanCopyExtensions.cs
+++ b/DotExtensions.Memory/Spans/SpanCopyExtensions.cs
@@ -29,6 +29,15 @@ namespace DotExtensions.Memory.Spans;
 /// </summary>
 public static class SpanCopyExtensions
 {
+    private static void ValidateCopyRange(int sourceLength, int startIndex, int length)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(startIndex);
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex, sourceLength);
+        if (startIndex + length > sourceLength)
+            throw new ArgumentOutOfRangeException(nameof(length));
+    }
+
     #region Span version
     /// <param name="source">The source span.</param>
     /// <typeparam name="T">The type of elements in the span.</typeparam>
@@ -55,12 +64,7 @@ public static class SpanCopyExtensions
             int startIndex,
             int length)
         {
-            ArgumentOutOfRangeException.ThrowIfNegative(startIndex);
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex, source.Length);
-            ArgumentOutOfRangeException.ThrowIfNegative(length);
-
-            if (startIndex + length > source.Length)
-                throw new ArgumentOutOfRangeException(nameof(length));
+            ValidateCopyRange(source.Length, startIndex, length);
 
             // If destination is too small, point it at a slice of the source to avoid per-element copies.
             if (destination.Length < length)
@@ -96,11 +100,7 @@ public static class SpanCopyExtensions
             int startIndex,
             int length)
         {
-            ArgumentOutOfRangeException.ThrowIfNegative(startIndex);
-            ArgumentOutOfRangeException.ThrowIfNegative(length);
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex, source.Length);
-            if (startIndex + length > source.Length)
-                throw new ArgumentOutOfRangeException(nameof(length));
+            ValidateCopyRange(source.Length, startIndex, length);
 
             if (destination.Length < length)
                 throw new ArgumentException(Resources.Exceptions_Spans_Copy_DestinationShorterThanSource, nameof(destination));
@@ -208,11 +208,7 @@ public static class SpanCopyExtensions
             int length
         )
         {
-            ArgumentOutOfRangeException.ThrowIfNegative(startIndex);
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex, source.Length);
-            ArgumentOutOfRangeException.ThrowIfNegative(length);
-            if (startIndex + length > source.Length)
-                throw new ArgumentOutOfRangeException(nameof(length));
+            ValidateCopyRange(source.Length, startIndex, length);
 
             if (destination.Length >= length)
             {
@@ -220,7 +216,7 @@ public static class SpanCopyExtensions
                 return;
             }
 
-            T[] outputArray = new T[length];
+            T[] outputArray = GC.AllocateUninitializedArray<T>(length);
             source.Slice(startIndex, length).CopyTo(outputArray);
             destination = outputArray.AsSpan();
         }

--- a/DotExtensions.Tests/Strings/StringRemoveAllTests.cs
+++ b/DotExtensions.Tests/Strings/StringRemoveAllTests.cs
@@ -1,0 +1,106 @@
+/*
+        MIT License
+
+       Copyright (c) 2026 Alastair Lundy
+
+       Permission is hereby granted, free of charge, to any person obtaining a copy
+       of this software and associated documentation files (the "Software"), to deal
+       in the Software without restriction, including without limitation the rights
+       to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+       copies of the Software, and to permit persons to whom the Software is
+       furnished to do so, subject to the following conditions:
+
+       The above copyright notice and this permission notice shall be included in all
+       copies or substantial portions of the Software.
+
+       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+       IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+       FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+       AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+       LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+       OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+       SOFTWARE.
+    */
+
+using System;
+using DotExtensions.Strings;
+
+namespace DotExtensions.Tests.Strings;
+
+public class StringRemoveAllTests
+{
+    [Test]
+    [Arguments("hello world", "xyz")]
+    [Arguments("abc", "abcdef")]
+    public async Task RemoveAll_ValueNotFound_ReturnsOriginal(string input, string value)
+    {
+        string result = input.RemoveAll(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(input);
+    }
+
+    [Test]
+    [Arguments("hello world", "world", "hello ")]
+    [Arguments("hello world", "hello", " world")]
+    [Arguments("abcXYZdef", "XYZ", "abcdef")]
+    [Arguments("aaa", "a", "")]
+    [Arguments("abcabc", "abc", "")]
+    public async Task RemoveAll_SingleOccurrence_RemovesCorrectly(string input, string value, string expected)
+    {
+        string result = input.RemoveAll(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("ababab", "ab", "")]
+    [Arguments("aXbXcXd", "X", "abcd")]
+    [Arguments("fooXXbarXXbaz", "XX", "foobarbaz")]
+    public async Task RemoveAll_MultipleOccurrences_RemovesAll(string input, string value, string expected)
+    {
+        string result = input.RemoveAll(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("Hello World", "hello", StringComparison.OrdinalIgnoreCase, " World")]
+    [Arguments("ABCABC", "abc", StringComparison.OrdinalIgnoreCase, "")]
+    public async Task RemoveAll_CaseInsensitiveComparison_RemovesCorrectly(
+        string input, string value, StringComparison comparison, string expected)
+    {
+        string result = input.RemoveAll(value, comparison);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task RemoveAll_NullSource_ThrowsArgumentException()
+    {
+        string? source = null;
+
+        await Assert.That(() => source!.RemoveAll("x", StringComparison.Ordinal))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task RemoveAll_EmptySource_ThrowsArgumentException()
+    {
+        await Assert.That(() => "".RemoveAll("x", StringComparison.Ordinal))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task RemoveAll_NullValue_ThrowsArgumentException()
+    {
+        await Assert.That(() => "hello".RemoveAll(null!, StringComparison.Ordinal))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task RemoveAll_EmptyValue_ThrowsArgumentException()
+    {
+        await Assert.That(() => "hello".RemoveAll("", StringComparison.Ordinal))
+            .Throws<ArgumentException>();
+    }
+}

--- a/DotExtensions/System/Strings/Removal/StringRemoveExtensions.cs
+++ b/DotExtensions/System/Strings/Removal/StringRemoveExtensions.cs
@@ -49,12 +49,35 @@ public static class StringRemoveExtensions
             ArgumentException.ThrowIfNullOrEmpty(str);
             ArgumentException.ThrowIfNullOrEmpty(value);
 
-            while (str.Contains(value, stringComparison))
+            int valueLength = value.Length;
+            int strLength = str.Length;
+
+            if (valueLength > strLength)
+                return str;
+
+            StringBuilder sb = new(strLength);
+            int searchStart = 0;
+
+            while (searchStart <= strLength - valueLength)
             {
-                str = str.RemoveFirst(value);
+                int index = str.IndexOf(value, searchStart, stringComparison);
+
+                if (index == -1)
+                {
+                    sb.Append(str, searchStart, strLength - searchStart);
+                    return sb.ToString();
+                }
+
+                if (index > searchStart)
+                    sb.Append(str, searchStart, index - searchStart);
+
+                searchStart = index + valueLength;
             }
 
-            return str;
+            if (searchStart < strLength)
+                sb.Append(str, searchStart, strLength - searchStart);
+
+            return sb.ToString();
         }
 
         /// <summary>

--- a/IMPLEMENTATION-2026-07-15.md
+++ b/IMPLEMENTATION-2026-07-15.md
@@ -1,0 +1,237 @@
+# Implementation Blueprint — DotExtensions v10 Performance Improvements
+
+## Scope Binding
+
+**Linked Spec**: This blueprint is a context pointer for the DotExtensions
+v10 performance improvement work. The functional "what" is captured in
+the Decision Ledger at
+`docs/decisions/DECISIONS-DotExtensions-performance-improvements.md`
+(records D001–D011), supplemented by the prior internal performance and
+memory audit (no standalone spec file exists; the audit is referenced
+from the handoff document at
+`C:\Users\alast\AppData\Local\Temp\opencode\DotExtensions-performance-handoff.md`).
+
+**Decision Ledger**: `docs/decisions/DECISIONS-DotExtensions-performance-improvements.md`
+
+**Cross-spec warning**: This blueprint is valid ONLY for the DotExtensions
+v10 performance improvement work linked above. It must not be applied to
+other specifications, libraries, or release windows without explicit
+authorization. The ledger records (Dxxx, Txxx) are specific to this
+spec and may not transfer to other work.
+
+## Ledger Reference
+
+Records cited in this blueprint (in order of citation):
+- `DECISIONS-DotExtensions-performance-improvements.md#D001` — session goal
+- `DECISIONS-DotExtensions-performance-improvements.md#D002` — package layout
+- `DECISIONS-DotExtensions-performance-improvements.md#D003` — v10/v11 perf strategy
+- `DECISIONS-DotExtensions-performance-improvements.md#D004` — v10 validation methodology
+- `DECISIONS-DotExtensions-performance-improvements.md#D005` — v10 vs v11 scope allocation
+- `DECISIONS-DotExtensions-performance-improvements.md#D006` — bug standard for v10 behavior changes
+- `DECISIONS-DotExtensions-performance-improvements.md#D007` — v10 sequencing
+- `DECISIONS-DotExtensions-performance-improvements.md#D008` — v10 polyfill strategy
+- `DECISIONS-DotExtensions-performance-improvements.md#D009` — v10 test coverage expectations
+- `DECISIONS-DotExtensions-performance-improvements.md#D010` — v10 AOT compatibility expectations
+- `DECISIONS-DotExtensions-performance-improvements.md#D011` — session closure
+- `DECISIONS-DotExtensions-performance-improvements.md#T001` — first v10 strings implementation
+- `DECISIONS-DotExtensions-performance-improvements.md#T002` — StringRemoveExtensions refactor approach
+- `DECISIONS-DotExtensions-performance-improvements.md#T003` — test approach for StringRemoveExtensions refactor
+- `DECISIONS-DotExtensions-performance-improvements.md#T004` — BDN benchmark approach for StringRemoveExtensions
+- `DECISIONS-DotExtensions-performance-improvements.md#T005` — PR description approach for StringRemoveExtensions refactor
+- `DECISIONS-DotExtensions-performance-improvements.md#T006` — existing Span optimization approach
+- `DECISIONS-DotExtensions-performance-improvements.md#T007` — additive Span API surface
+- `DECISIONS-DotExtensions-performance-improvements.md#T008` — v10 internal-refactor category scope
+- `DECISIONS-DotExtensions-performance-improvements.md#T009` — polyfill content audit
+- `DECISIONS-DotExtensions-performance-improvements.md#T010` — Span<char>.RemoveAll type design
+
+## v10 Sequence (per D007)
+
+The v10 work follows the sequence: strings → existing Span → additive Span API → internal-refactor categories.
+
+---
+
+## Category 1: Strings (D005, D007)
+
+### First deliverable: StringRemoveExtensions (T001)
+
+The first v10 strings PR is `DotExtensions/System/Strings/Removal/StringRemoveExtensions.cs`
+[T001]. The other string extension files wait for subsequent TDPs.
+
+### Refactor approach (T002)
+
+`RemoveAll` is rewritten with a single-pass scan that appends non-matching
+runs to a `StringBuilder` and returns `sb.ToString()`. `RemoveFirst` and
+`RemoveLast` retain their current `string.Remove` allocation and are
+addressed in a future PR [T002].
+
+**Constraints**:
+- Behavior preservation per D006 [T002]: null/empty throws, same return values.
+- The `StringBuilder` scan uses a manual loop, not `string.Replace` (no culture-aware overload on `netstandard2.0`).
+- `RemoveFirst` and `RemoveLast` allocations are deferred; tracked as a follow-up TDP.
+
+### Test approach (T003)
+
+Tests assert the documented contract for each method (per XML doc comments),
+cover standard edge cases, exercise each `StringComparison` value, and use
+TUnit `[Arguments]` to parameterize inputs [T003]. Culture-specific results
+are pinned to ASCII or stable Unicode to avoid flakiness. Allocation count
+assertions are excluded (the BDN benchmark per D004 [T004] covers allocation
+regression).
+
+### Benchmark approach (T004)
+
+A BDN benchmark in `DotExtensions.Benchmarking` covers all three methods
+across short (16 chars), medium (256 chars), and long (4096 chars) inputs,
+producing a 3 × 3 matrix [T004]. Per D004, this benchmark is the v11
+baseline for `StringRemoveExtensions`. Culture-specific comparison
+benchmarks are deferred.
+
+### PR description (T005)
+
+The PR description includes "What changed", "Why", "How" sections plus a
+BDN benchmark results table (method × size × mean × allocated) [T005].
+Per D006, this PR does not change behavior, so the D006 contract citation
+is not required. BDN memory columns are excluded from the PR table.
+
+---
+
+## Category 2: Existing Span (D005, D007)
+
+### Optimization approach (T006)
+
+The existing Span code in `DotExtensions.Memory/Spans/` is optimized by
+[T006]:
+- Consolidating the `ArgumentOutOfRangeException.ThrowIf*` calls into a
+  shared private static helper used by all `CopyTo`/`OptimisticCopy`
+  overloads.
+- Replacing `T[] outputArray = new T[length]` in
+  `ReadOnlySpan<T>.OptimisticCopy` with
+  `GC.AllocateUninitializedArray<T>(length)`.
+
+**Constraints**:
+- Per D006, the `try/catch` safety net in `TryCopyTo` and the allocation
+  in `Resize` are deliberate behavior and stay in v10.
+- Per D008, `GC.AllocateUninitializedArray` is `net8.0+`; for
+  `netstandard2.0`, a conditional compilation or polyfill is required.
+  The existing `Polyfill` package reference is verified per T009.
+- The shared validation helper preserves the exact exception types and
+  `paramName` values of the current inline checks (D006).
+
+---
+
+## Category 3: Additive Span API (D005, D007)
+
+### API surface (T007)
+
+The v10 additive API in `DotExtensions.Memory` adds `Span<char>` and
+`ReadOnlySpan<char>` overloads for the string extension methods in the
+strings category: `RemoveAll`, `RemoveFirst`, `RemoveLast` (from
+`Removal/StringRemoveExtensions.cs`), `StringInsertExtensions`,
+`StringReverseExtensions`, and the other `Removal/*` files
+(`StringRemoveRangeExtensions`, `StringReplaceLastExtensions`) [T007].
+
+**Constraints**:
+- Per D008, no new polyfill packages; the existing `Polyfill` package
+  reference covers `netstandard2.0` (verified per T009).
+- Per D009, each new overload gets a public API test (consumer-perspective).
+- Per D010, each new overload gets an AOT runtime test in
+  `DotExtensions.AotTests`.
+- Per D004, each new overload gets a BDN benchmark in
+  `DotExtensions.Benchmarking`.
+- Non-`char` types and `ReadOnlyMemory<char>` overloads are not in v10;
+  they can be expanded in v11.
+
+### Type design: Span<char>.RemoveAll (T010)
+
+```csharp
+extension(ref Span<char> source)
+{
+    public int RemoveAll(
+        ReadOnlySpan<char> value,
+        StringComparison stringComparison = StringComparison.CurrentCulture);
+}
+```
+
+Returns the new length after removal; caller slices with
+`source = source[..result]`. Behavior mirrors `string.RemoveAll` per
+D006. The other two types in the partial loop
+(`Span<char>.RemoveFirst`, `Span<char>.RemoveLast`) are deferred to
+implementation; their signatures follow the same `ref Span<char>` +
+`int` return pattern.
+
+---
+
+## Category 4: Internal-refactor (D005, D007)
+
+### Scope (T008)
+
+v10 internal-refactor work covers collection/array allocations and
+boxing/conversion issues only [T008]. LINQ/enumerator and async/await
+internal optimizations are deferred to v11. v10 updates are scoped to
+remain manageable in size; each finding is a separate PR, not batched
+into a single large update.
+
+**Constraints**:
+- Per D006, every v10 internal-refactor change preserves observable
+  behavior; the documented-contract standard applies.
+- Per D005, v10 is backwards-compatible; collection/array and
+  boxing/conversion changes are internal refactors (no new public API
+  surface).
+
+---
+
+## Cross-cutting Concerns
+
+### Polyfill strategy (D008, T009)
+
+No new polyfill package dependencies in v10 [D008]. The additive Span
+API in T007 is verified against the existing `Polyfill` package via
+document audit [T009]. Any gap is worked around in the additive API
+design or escalated, not silently polyfilled with a new dependency.
+
+### Test coverage (D009)
+
+Test coverage bar: maintain existing + add invariant tests for changed
+methods + add public API tests for new additive API [D009]. Invariant
+tests assert the documented contract (per D006), not the refactor's
+implementation, to avoid tautological assertions.
+
+### AOT compatibility (D010)
+
+The existing `DotExtensions.AotTests` AOT build (`<PublishAot>true`,
+`<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`,
+`<EnableAotAnalyzer>true</EnableAotAnalyzer>`) is the compile-time gate
+[D010]. Each new additive Span overload in T007 gets an AOT runtime
+test in `DotExtensions.AotTests`. v10 internal refactors in the main
+package are verified by the existing AOT build only.
+
+### Validation methodology (D004)
+
+The BDN benchmark project at `DotExtensions.Benchmarking` is extended
+with new benchmarks for the v10 additive Span methods in
+`DotExtensions.Memory` and backfilled with benchmarks for existing v10
+methods in the main package that currently have no benchmarks [D004].
+The v10 final state (post-implementation, with full benchmark coverage)
+becomes the v11 baseline.
+
+---
+
+## v11 (per D003)
+
+v11 drops `netstandard2.0` from `DotExtensions` and
+`DotExtensions.Memory` and uses `net8.0+`-only APIs (modern
+`MemoryExtensions`, hardware-accelerated paths) for aggressive perf
+wins [D003]. v11 also takes the deferred work from v10: LINQ/enumerator
+allocations, async/await internal optimizations, algorithmic
+inefficiencies, and exception-as-control-flow anti-patterns. v11 may
+also restructure the package layout (currently frozen per D002).
+
+## Glossary
+
+- **BDN** — BenchmarkDotNet, the .NET microbenchmarking library used in
+  `DotExtensions.Benchmarking`.
+- **Polyfill** — the NuGet package referenced by `DotExtensions.Memory`
+  that provides `netstandard2.0` polyfills for modern .NET APIs.
+- **TFM** — Target Framework Moniker (e.g., `netstandard2.0`, `net8.0`).
+- **TDP** — Technical Decision Point, a technical choice extracted from
+  the spec during the `code-implementation-grilling` workflow.

--- a/docs/decisions/DECISIONS-DotExtensions-performance-improvements.md
+++ b/docs/decisions/DECISIONS-DotExtensions-performance-improvements.md
@@ -1,0 +1,500 @@
+# Decision Ledger — DotExtensions performance improvements
+
+## Goal
+
+Drive measurable performance and memory-efficiency improvements across the
+DotExtensions library suite, distributed across the v10 and v11 release windows.
+
+## Conventions
+
+- `Dxxx` — functional/governance decision.
+- `Txxx` — technical implementation decision (recorded in a follow-up session
+  per `code-implementation-grilling` workflow).
+- Re-opens use a fresh `Dxxx` and a `Supersedes: Dxxx` line in `Constraints`.
+
+## Records
+
+### [D001] — session goal
+
+- **Driver**: the user wants measurable performance wins in DotExtensions
+  while controlling consumer-facing risk per release.
+- **Resolved Answer**: "For v10: string optimisations; Span-based usage
+  where it's not a breaking change; optimisation of existing Span usage.
+  For v11: probably drop .NET Standard 2.0; more aggressively chase
+  performance improvements."
+- **Normalized Requirement**: v10 shall ship performance improvements that
+  are SemVer-compatible (no signature changes, no removals); v11 shall ship
+  performance improvements that may include breaking changes, including
+  dropping `netstandard2.0` from supported target frameworks.
+- **Constraints**:
+  - The v10/v11 operational strategy (which categories of changes to make
+    in which order) is tracked as a separate branch and is currently open
+    (resolved as D003 in this session).
+  - "Breaking change" includes signature changes, removals, behavior changes
+    visible to consumers, and dropping target frameworks.
+
+### [D002] — package layout (Memory vs main)
+
+- **Driver**: the user wants v10 strictly backwards-compatible and v11 free
+  to make breaking changes; the package layout must respect that boundary
+  so v10 carries no consumer-facing layout risk.
+- **Resolved Answer**: "Keep `DotExtensions.Memory` separate, frozen in v10;
+  revisit in v11."
+- **Normalized Requirement**: in v10, `DotExtensions` and `DotExtensions.Memory`
+  remain two separate NuGet projects with their current shape; any v10
+  additive Span/Memory API surface shall land in `DotExtensions.Memory`,
+  not the main package. v11 may merge, restructure, or refactor the layout
+  with a documented migration story.
+- **Constraints**:
+  - v10 additive Span/Memory API must go in `DotExtensions.Memory`; the main
+    package's v10 scope is internal-refactor-only.
+  - v11's `netstandard2.0` drop applies to both packages (or to whichever
+    package the v11 strategy chooses); it is *not* a v10 action.
+  - If a v11 merge forces a namespace migration, the migration story is part
+    of the v11 release.
+
+### [D003] — v10/v11 perf strategy
+
+- **Driver**: the user wants the operational strategy to operationalize
+  D001's v10/v11 boundary with the specific perf categories they named
+  (string allocations, additive Span, existing Span optimization), while
+  respecting D002's package-layout constraint.
+- **Resolved Answer**: "Option 3 — Additive v10 (in Memory) + aggressive v11
+  (drop netstandard2.0 first)."
+- **Normalized Requirement**: v10 shall (a) add new `Span<T>` /
+  `ReadOnlySpan<T>` / `Memory<T>` overloads in `DotExtensions.Memory`,
+  (b) refactor hot paths in the main package internally (string allocations,
+  Span reuse, existing Span usage) without adding new public types, and
+  (c) keep the main package at zero new public types. v11 shall drop
+  `netstandard2.0` from both packages and use `net8.0+`-only APIs
+  (e.g., modern `MemoryExtensions`, hardware-accelerated paths) for
+  aggressive perf wins; v11 may also deprecate/remove the v10 additively-
+  grown Memory overloads.
+- **Constraints**:
+  - Per D002, v10 additive Span/Memory API lands in `DotExtensions.Memory`,
+    not the main package.
+  - v10 main package scope is internal-refactor-only.
+  - The v11 `netstandard2.0` drop is a v11 action, not v10.
+  - v11's perf wins depend on `net8.0+` APIs that have no `netstandard2.0`
+    equivalent; if a future framework target must be added back, the wins
+    are not portable.
+
+### [D004] — v10 validation methodology
+
+- **Driver**: the user wants v10 perf wins to be measurable (proof the work
+  landed) and the BDN project to produce a captured v10 state that v11 can
+  compare against to quantify v11 deltas.
+- **Resolved Answer**: "Add benchmarks for the new v10 additive methods and
+  for existing v10 methods missing benchmarks." (Option 1 — Cover new +
+  backfill existing.)
+- **Normalized Requirement**: `DotExtensions.Benchmarking` shall be extended
+  with new benchmarks for the v10 additive Span/Memory methods in
+  `DotExtensions.Memory`, and backfilled with benchmarks for existing v10
+  methods in the main package that currently have no benchmarks. The v10
+  final state (post-implementation, with full benchmark coverage) becomes
+  the v11 baseline.
+- **Constraints**:
+  - v9 is out of scope; benchmarks and baselines reference v10 and v11 only.
+  - v10 release is gated on benchmark coverage of the changed surface and
+    the backfilled existing surface.
+  - Backfill benchmarks for unchanged methods may surface existing perf
+    characteristics that aren't related to the v10 work; the v10→v11
+    comparison narrative must account for this.
+
+### [D005] — v10 vs v11 scope allocation
+
+- **Driver**: the user wants v10 to ship the categories that are both
+  high-impact ("big enough change") and low-risk ("low hanging fruit")
+  within a backwards-compatible release, and v11 to take the aggressive
+  pass on the rest.
+- **Resolved Answer**: "Option 2 but every change has to retain existing
+  behaviour unless the existing behaviour has bugs."
+- **Normalized Requirement**: v10 shall cover (a) string manipulation
+  allocations, (b) Span/Memory additive API in `DotExtensions.Memory`,
+  (c) optimization of existing Span usage, and (d) the low-hanging
+  internal-refactor items from LINQ/enumerator allocations,
+  collection/array allocations, boxing/conversion issues, and async/await
+  internal optimizations. v11 shall take algorithmic inefficiencies,
+  exception-as-control-flow, and the aggressive perf pass with `net8.0+`
+  APIs. Every v10 change shall preserve existing observable behavior
+  unless the existing behavior is a bug as defined in D006.
+- **Constraints**:
+  - v10 main package is internal-refactor-only; additive API lands in
+    `DotExtensions.Memory` per D002.
+  - v10 behavior changes are permitted only to fix bugs (D006).
+  - "Internal-refactor" is a judgment call; a v10 change that is actually
+    behavior-changing surfaces as a v10 regression, not a v11 opportunity.
+
+### [D006] — bug standard for v10 behavior changes
+
+- **Driver**: the user wants v10 behavior changes permitted only when the
+  existing behavior is a bug, but "bug" is subjective without a standard.
+- **Resolved Answer**: "Option 1 — Documented behavior is the contract;
+  deviation is a bug."
+- **Normalized Requirement**: a behavior change in v10 is permitted only
+  when (a) the new behavior matches the method's XML doc comments / public
+  documentation, and (b) the current implementation deviates from that
+  documented behavior. Undocumented behavior is not protected by this
+  standard; a v10 change to undocumented behavior is a breaking change
+  and must be deferred to v11.
+- **Constraints**:
+  - The standard applies to v10 only; v11 behavior changes are governed
+    by the v11 breaking-change window, not D006.
+  - A v10 PR that changes behavior must cite the relevant XML doc comment
+    and demonstrate the deviation in the PR description.
+  - Undocumented correct behavior that gets "fixed" in v10 is a
+    forward risk; the fix is technically allowed because there's no doc
+    to defend the old behavior.
+
+### [D007] — v10 sequencing
+
+- **Driver**: the user wants v10 categories addressed in an order that
+  maximizes early consumer-visible wins while keeping the additive Span
+  API and internal-refactor categories from consuming v10 capacity first.
+- **Resolved Answer**: "Option 1 — Impact-first (strings → existing Span →
+  Span additive → internal-refactor categories)."
+- **Normalized Requirement**: v10 shall address the categories in this
+  order: (1) string manipulation allocations, (2) optimization of existing
+  Span usage, (3) additive Span/Memory API in `DotExtensions.Memory`,
+  (4) internal-refactor items from LINQ/enumerator allocations,
+  collection/array allocations, boxing/conversion issues, and async/await
+  internal optimizations. Each category is a discrete phase; within-
+  category finding selection is a separate branch.
+- **Constraints**:
+  - The additive Span API lands late in v10; if a v10 capacity crunch
+    hits, the new public surface is the first thing cut.
+  - Internal refactors must preserve observable behavior per D006.
+  - Per D004, benchmarks for each category land alongside the category
+    implementation, not after.
+
+### [D008] — v10 polyfill strategy for the Memory package
+
+- **Driver**: the user wants the v10 additive Span/Memory API in
+  `DotExtensions.Memory` to work on `netstandard2.0` without expanding the
+  polyfill surface or adding new polyfill dependencies.
+- **Resolved Answer**: "To the extent Option 1 is necessary we use Option 1
+  but I don't expect any new/additional polyfilling packages will be needed
+  for v10."
+- **Normalized Requirement**: the v10 additive Span/Memory API in
+  `DotExtensions.Memory` shall rely on the existing `Polyfill` NuGet
+  package reference for any `netstandard2.0` polyfills. No new polyfill
+  packages shall be added in v10. Custom polyfills in
+  `DotExtensions.Memory/Polyfills/` are written only if the `Polyfill`
+  package cannot cover a required API gap; the user expects no such gap
+  for the v10 additive Span API.
+- **Constraints**:
+  - No new polyfill package dependencies in v10.
+  - If a `netstandard2.0` API gap surfaces for the v10 additive Span API
+    that the `Polyfill` package does not cover, the gap is either worked
+    around in the additive API design or escalated (not silently polyfilled
+    with a new dependency).
+  - v11 drops `netstandard2.0` from `DotExtensions.Memory` per D003; v11
+    removes the `Polyfill` package reference and any custom polyfills in
+    `DotExtensions.Memory/Polyfills/` in one coordinated change.
+
+### [D009] — v10 test coverage expectations
+
+- **Driver**: the user wants v10 internal refactors to be verifiably
+  behavior-preserving per D006, and the v10 additive Span API in
+  `DotExtensions.Memory` to be regression-protected for consumers.
+- **Resolved Answer**: "Option 4 — All of the above (maintain + increase
+  for changed + add public API tests)."
+- **Normalized Requirement**: v10 changes shall (a) maintain existing test
+  coverage line/branch percentages at least constant — refactors that drop
+  coverage are rejected; (b) add invariant-specific tests for every
+  refactored method that exercise the contract the refactor relies on;
+  (c) add consumer-perspective public API tests for every new additive
+  Span/Memory overload in `DotExtensions.Memory`.
+- **Constraints**:
+  - Invariant-specific tests must assert the *documented contract* per D006,
+    not the refactor's implementation, to avoid tautological assertions.
+  - Public API tests for the additive Span overloads must use the API as
+    a consumer would, not couple to internal implementation details.
+  - The existing test framework is TUnit (`await Assert.That(...)`) per
+    `AGENTS.md`; no framework change in v10.
+
+### [D010] — v10 AOT compatibility expectations
+
+- **Driver**: the user wants the v10 additive Span API in
+  `DotExtensions.Memory` to be verified to work under NativeAOT, not just
+  compile clean; the existing AOT build gate is necessary but not
+  sufficient for new public surface.
+- **Resolved Answer**: "Option 2 — Add AOT-specific runtime tests for the
+  v10 additive Span API in Memory."
+- **Normalized Requirement**: every new additive Span/Memory overload in
+  `DotExtensions.Memory` shall have a runtime test in
+  `DotExtensions.AotTests` that exercises the public API under NativeAOT.
+  The existing `DotExtensions.AotTests` AOT build remains the compile-time
+  gate for the entire library. v10 internal refactors in the main package
+  are verified by the existing AOT build only; no explicit AOT runtime
+  tests are required for refactored methods unless a specific AOT risk
+  is identified.
+- **Constraints**:
+  - The existing `DotExtensions.AotTests` AOT build (`<PublishAot>true`,
+    `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`,
+    `<EnableAotAnalyzer>true</EnableAotAnalyzer>`) is the compile-time
+    gate; v10 changes that introduce AOT warnings fail the build.
+  - AOT runtime tests for the additive Span API must use the API as a
+    consumer would, mirroring the public API tests in D009.
+  - AOT runtime tests may not catch all AOT-specific paths (e.g., JIT vs
+    AOT codegen differences); the AOT build gate is the primary safety
+    net for compile-time AOT safety.
+
+### [D011] — session closure
+
+- **Driver**: the user wants to close the D-level governance session and
+  move to T-level implementation grilling; the remaining open work is
+  implementation-level (specific files, API signatures, CI wiring) and is
+  better made in the PR process.
+- **Resolved Answer**: "Option 1 — Close the session; move to
+  implementation planning with D001–D010 as the governance baseline.
+  Let's move to code implementation grilling."
+- **Normalized Requirement**: the D-level governance session is closed;
+  D001–D010 are the governance baseline for the v10 work. T-level
+  (technical implementation) decisions are tracked as `Txxx` records in
+  this same ledger, beginning with T001 for the first v10 strings
+  implementation.
+- **Constraints**:
+  - Implementation-level decisions (specific files, API signatures, CI
+    wiring) are made during the work, not in this grilling session.
+  - Any contradiction with D001–D010 that surfaces during implementation
+    is a `Supersedes: Dxxx` re-open, not a silent override.
+  - The v10 sequence in D007 (strings → existing Span → Span additive →
+    internal-refactor categories) governs the order of T-level work.
+
+## T-level records (implementation)
+
+### [T001] — first v10 strings implementation
+
+- **Resolved Answer**: "Option 1 — `StringRemoveExtensions.cs` first, single file."
+- **Normalized Requirement**: v10 strings work shall begin with
+  `DotExtensions/System/Strings/Removal/StringRemoveExtensions.cs`; the
+  verified allocation issues in that file are addressed in a single PR.
+  The other string extension files in `DotExtensions/System/Strings/`
+  wait for subsequent `Txxx` records.
+- **Constraints**:
+  - The refactor must preserve observable behavior per D006; tests must
+    assert the documented contract, not the refactor's implementation.
+  - Test coverage per D009: existing coverage is maintained, invariant-
+    specific tests are added for the refactored methods, and public API
+    tests are added if the refactor introduces new public surface.
+  - AOT compatibility per D010: the existing `DotExtensions.AotTests`
+    AOT build is the compile-time gate; this file is in the main package
+    (not Memory), so no explicit AOT runtime tests are required unless a
+    specific AOT risk is identified.
+  - Benchmarks per D004: a BDN benchmark for `StringRemoveExtensions`
+    shall be added in `DotExtensions.Benchmarking` alongside the refactor.
+  - The pattern from `StringRemoveExtensions` may not transfer cleanly to
+    other string files with different allocation profiles; later files
+    need their own TDP.
+- **Cites**: D005, D006, D007, D009, D010, D004.
+
+### [T002] — StringRemoveExtensions refactor approach
+
+- **Resolved Answer**: "Option 1 with a note to address RemoveFirst and
+  RemoveLast in a future PR."
+- **Normalized Requirement**: v10 `StringRemoveExtensions` refactor shall
+  rewrite `RemoveAll` with a single-pass scan that appends non-matching
+  runs to a `StringBuilder` and returns `sb.ToString()`. `RemoveFirst`
+  and `RemoveLast` retain their current `string.Remove` allocation and
+  are addressed in a future PR (tracked as a follow-up `Txxx`).
+- **Constraints**:
+  - Per D006, observable behavior is preserved: null/empty throws,
+    "not found" throws for `RemoveFirst`/`RemoveLast` (those methods
+    are unchanged), same return values for all three methods.
+  - The `StringBuilder` scan must use a manual loop, not
+    `string.Replace` (which has no culture-aware overload on
+    `netstandard2.0`).
+  - Per D009, invariant tests assert the documented contract (per the
+    XML doc comments), not the refactor's implementation.
+  - Per D004, a BDN benchmark for `RemoveAll` (and ideally the unchanged
+    methods) is added in `DotExtensions.Benchmarking` alongside the
+    refactor.
+  - `RemoveFirst` and `RemoveLast` allocations are deferred; a follow-up
+    TDP tracks their treatment in a later PR.
+- **Cites**: D005, D006, D007, D009, D004.
+
+### [T003] — test approach for StringRemoveExtensions refactor
+
+- **Resolved Answer**: "Option 3 — Contract tests + edge case tests +
+  comparison tests + parameterized inputs (TUnit `[Arguments]`)."
+- **Normalized Requirement**: v10 `StringRemoveExtensions` tests shall
+  (a) assert the documented contract for `RemoveAll`, `RemoveFirst`, and
+  `RemoveLast` per their XML doc comments, (b) cover the standard edge
+  cases (null/empty inputs, value not found, value longer than input,
+  value equals entire input, single occurrence, multiple occurrences),
+  (c) exercise each `StringComparison` value and assert the result
+  matches the comparison's semantics, and (d) use TUnit `[Arguments]` to
+  parameterize inputs across short/medium/long strings, value positions,
+  overlapping values, and Unicode.
+- **Constraints**:
+  - Per D009, tests assert the documented contract, not the refactor's
+    implementation, to avoid tautological assertions.
+  - Per D006, the contract source is the XML doc comments; any behavior
+    not covered by the doc comments is out of scope for the invariant
+    tests.
+  - Culture-specific results can vary by runtime/ICU version; test
+    inputs are pinned to ASCII or stable Unicode to avoid flakiness.
+  - Allocation count assertions are the BDN benchmark's job per D004,
+    not the unit test's.
+- **Cites**: D006, D009, D004.
+
+### [T004] — BDN benchmark approach for StringRemoveExtensions
+
+- **Resolved Answer**: "Option 3 — All three methods + multiple input
+  sizes (short, medium, long)."
+- **Normalized Requirement**: v10 `StringRemoveExtensions` BDN benchmark
+  in `DotExtensions.Benchmarking` shall cover all three methods
+  (`RemoveAll`, `RemoveFirst`, `RemoveLast`) across short (16 chars),
+  medium (256 chars), and long (4096 chars) inputs, producing a 3 × 3
+  matrix of benchmark methods.
+- **Constraints**:
+  - Per D004, the v10 final state (this benchmark included) becomes
+    the v11 baseline; the benchmark is the regression net for v11
+    changes to these methods.
+  - Inputs are kept simple (ASCII, no culture-specific characters) to
+    keep BDN memory columns low and avoid culture-specific flakiness.
+  - Culture-specific comparison benchmarks are deferred; if a v11
+    change is comparison-specific, comparison benchmarks are added
+    then.
+  - The benchmark class is large (9 benchmark methods); CI time
+    grows accordingly.
+- **Cites**: D004, D007.
+
+### [T005] — PR description approach for StringRemoveExtensions refactor
+
+- **Resolved Answer**: "Option 2 — Standard PR description + benchmark
+  results table."
+- **Normalized Requirement**: v10 `StringRemoveExtensions` refactor PR
+  description shall include a "What changed", "Why", and "How" section,
+  plus a BDN benchmark results table (method × size × mean × allocated)
+  for the 3 × 3 matrix from T004. The table is generated by running BDN
+  and pasting the output.
+- **Constraints**:
+  - Per D006, this PR does not change behavior, so the D006 contract
+    citation is not required; the PR description states that the
+    refactor preserves the documented contract.
+  - The benchmark results table may become stale if benchmark inputs
+    change; the PR description is updated as part of the PR checklist
+    whenever the benchmark is rerun.
+  - BDN memory columns are excluded from the PR table; they are
+    analyzed in the BDN HTML report, not in the PR.
+- **Cites**: D006, D004.
+
+### [T006] — existing Span optimization approach
+
+- **Resolved Answer**: "Option 3 — Both: consolidate validation + use
+  `GC.AllocateUninitializedArray`."
+- **Normalized Requirement**: v10 existing Span optimization in
+  `DotExtensions.Memory/Spans/` shall (a) consolidate the
+  `ArgumentOutOfRangeException.ThrowIf*` calls into a shared private
+  static helper used by all `CopyTo`/`OptimisticCopy` overloads, and
+  (b) replace `T[] outputArray = new T[length]` in
+  `ReadOnlySpan<T>.OptimisticCopy` with
+  `GC.AllocateUninitializedArray<T>(length)`.
+- **Constraints**:
+  - Per D006, the `try/catch` safety net in `TryCopyTo` and the
+    allocation in `Resize` are deliberate behavior and stay in v10.
+  - Per D008, `GC.AllocateUninitializedArray` is `net8.0+`; for
+    `netstandard2.0`, a conditional compilation or polyfill is
+    required. Verify the existing `Polyfill` package reference covers
+    it before relying on it.
+  - The shared validation helper must preserve the exact exception
+    types and `paramName` values of the current inline checks to
+    satisfy D006's documented-contract standard.
+- **Cites**: D005, D006, D007, D008.
+
+### [T007] — additive Span API surface
+
+- **Resolved Answer**: "Option 1 — String-focused: `Span<char>` /
+  `ReadOnlySpan<char>` overloads for the strings category."
+- **Normalized Requirement**: v10 additive API in `DotExtensions.Memory`
+  shall add `Span<char>` and `ReadOnlySpan<char>` overloads for the
+  string extension methods in the strings category: `RemoveAll`,
+  `RemoveFirst`, `RemoveLast` (from `Removal/StringRemoveExtensions.cs`),
+  `StringInsertExtensions`, `StringReverseExtensions`, and the other
+  `Removal/*` files (`StringRemoveRangeExtensions`,
+  `StringReplaceLastExtensions`).
+- **Constraints**:
+  - Per D008, no new polyfill packages; the existing `Polyfill` package
+    reference covers `netstandard2.0`.
+  - Per D009, each new overload gets a public API test (consumer-
+    perspective).
+  - Per D010, each new overload gets an AOT runtime test in
+    `DotExtensions.AotTests`.
+  - Per D004, each new overload gets a BDN benchmark in
+    `DotExtensions.Benchmarking`.
+  - Non-`char` types (e.g., `Span<byte>` for IO) are not added in v10;
+    they can be expanded in v11 if demand exists.
+  - `ReadOnlyMemory<char>` overloads are not added in v10; they can be
+    added in v11.
+- **Cites**: D003, D005, D007, D008, D009, D010, D004.
+
+### [T008] — v10 internal-refactor category scope
+
+- **Resolved Answer**: "Option 3 — I don't want the v10 update(s) to
+  become unwieldy in size."
+- **Normalized Requirement**: v10 internal-refactor work shall cover
+  collection/array allocations and boxing/conversion issues only. LINQ/
+  enumerator allocations and async/await internal optimizations are
+  deferred to v11. v10 updates are scoped to remain manageable in size;
+  the user has explicitly named update size as a first-class concern.
+- **Constraints**:
+  - Per D006, every v10 internal-refactor change must preserve
+    observable behavior; the documented-contract standard applies.
+  - Per D005, v10 is backwards-compatible; collection/array and
+    boxing/conversion changes are internal refactors (no new public
+    API surface).
+  - The v10 update size concern constrains per-PR scope: each
+    collection/array or boxing/conversion finding is a separate PR,
+    not batched into a single large update.
+  - LINQ/enumerator and async/await work is deferred to v11; v11's
+    aggressive pass per D003 covers these.
+- **Cites**: D005, D006, D007.
+
+### [T009] — polyfill content audit
+
+- **Resolved Answer**: "Option 1 — Document audit."
+- **Normalized Requirement**: v10 polyfill audit shall read the `Polyfill`
+  NuGet package documentation and verify coverage of each API the
+  additive Span API (T007) needs on `netstandard2.0`. The audit records
+  each API as: covered (no action), not covered (work around in API
+  design per D008), or partially covered (verify the specific overload).
+  Any gap requiring a new polyfill package is escalated per D008.
+- **Constraints**:
+  - Per D008, no new polyfill packages in v10; gaps are worked around
+    in the additive API design or escalated, not silently polyfilled
+    with a new dependency.
+  - The audit is a verification step, not a design step; the result is
+    a recorded list of polyfill decisions before implementation.
+  - The audit's confidence is bounded by the `Polyfill` package's
+    documentation; if the docs are ambiguous, a prototype (T009 Option 2)
+    is the fallback.
+- **Cites**: D008, T007.
+
+### [T010] — Span<char>.RemoveAll type design
+
+- **Resolved Answer**: "Ready to move on." (Type 1 of 3 in the partial
+  type loop; `Span<char>.RemoveFirst` and `Span<char>.RemoveLast`
+  deferred to implementation.)
+- **Normalized Requirement**: v10 `Span<char>.RemoveAll` shall be a
+  C# 14 extension method on `ref Span<char>` with signature
+  `(ReadOnlySpan<char> value,
+    StringComparison stringComparison = StringComparison.CurrentCulture)`
+  returning `int` (the new length of the span after removal). It throws
+  `ArgumentException` when `value` is empty. The behavior mirrors the
+  documented contract of the main package's `string.RemoveAll` per D006.
+- **Constraints**:
+  - The `ref Span<char>` receiver is required because removing shortens
+    the span; the `int` return communicates the new length without
+    forcing a reallocation.
+  - Caller usage: `int newLength = source.RemoveAll(value);
+    source = source[..newLength];`
+  - Per D006, observable behavior matches `string.RemoveAll`: null/empty
+    `value` throws, the result equals the input with all occurrences
+    removed under the specified comparison.
+  - The other two types in the partial loop (`Span<char>.RemoveFirst`,
+    `Span<char>.RemoveLast`) are deferred to implementation; their
+    signatures follow the same `ref Span<char>` + `int` return pattern
+    unless implementation reveals a reason to deviate.
+- **Cites**: D003, D005, D006, D007, T007, T002.

--- a/docs/decisions/INTERNAL-REFACTOR-AUDIT-v10.md
+++ b/docs/decisions/INTERNAL-REFACTOR-AUDIT-v10.md
@@ -1,0 +1,319 @@
+# Internal Refactor Audit — v10 Collection/Array + Boxing/Conversion
+
+## Purpose
+
+Audit of the main `DotExtensions` package source files for collection/array
+allocation hotspots and boxing/conversion issues. Each finding is documented
+with file path, line number, current behavior, proposed fix, and estimated
+impact. Each actionable finding becomes a separate v10 PR per T008.
+
+## Scope
+
+Per T008, v10 internal-refactor work covers collection/array allocations and
+boxing/conversion issues only. LINQ/enumerator allocations and async/await
+internal optimizations are deferred to v11.
+
+## Out of Scope (Deferred to v11)
+
+- LINQ/enumerator allocations (iterator object allocations from `.Where()`,
+  `.Select()`, etc.) — deferred to v11 per T008.
+- async/await internal optimizations — deferred to v11 per T008.
+- Findings marked "by design" where the materialization is the explicit
+  purpose of the API (e.g., `SafelyGet*` methods that return arrays).
+
+---
+
+## Category A: Collection/Array Allocation Hotspots
+
+### A-1 — CharacterConstants.EscapeCharacters allocates on every access
+
+- **File:** `DotExtensions/System/Strings/Constants/CharacterConstants.cs`
+- **Line:** 37
+- **Current behavior:** `EscapeCharacters` is a get-only property using a
+  collection expression (`=> [...]`). Every access allocates a new `string[]`.
+  Accessed inside loops in `EscapeCharacterRemovalExtensions.cs` (lines 45, 58).
+- **Proposed fix:** Cache in a `static readonly` field:
+  `public static readonly string[] EscapeCharacters = [...];`
+- **Impact:** Medium. Small array (12 elements) but allocated on every access
+  inside loops.
+
+### A-2 — ContainsSubstringsExtensions.Split allocates array to check count
+
+- **File:** `DotExtensions/System/Strings/Contains/ContainsSubstringsExtensions.cs`
+- **Line:** 52
+- **Current behavior:** `s.Split(delimiter).Length > 1` allocates a full
+  `string[]` just to check whether there is more than one element.
+- **Proposed fix:** Replace with a second `IndexOf` call starting after the
+  first match: `int firstIdx = s.IndexOf(delimiter);
+  return firstIdx != -1 && s.IndexOf(delimiter, firstIdx + 1) != -1;`
+- **Impact:** Medium. `string.Split` allocates an array plus one string per
+  segment.
+
+### A-3 — GetRandomIOExtensions materializes directory tree in loop
+
+- **File:** `DotExtensions/System/IO/GetRandomIOExtensions.cs`
+- **Lines:** 154-155
+- **Current behavior:** Inside a `while(true)` loop,
+  `.SafelyEnumerateDirectories().Where(d => d.HasFiles).ToArray()` materializes
+  a filtered directory enumeration into a new array on every iteration.
+- **Proposed fix:** Use lazy enumeration with `FirstOrDefault()` or a
+  stack-based approach rather than materializing the full filtered set.
+- **Impact:** High. Repeated allocation inside a potentially unbounded loop.
+  Each iteration allocates LINQ iterators and a full array.
+- **Note:** The LINQ iterator allocation part is v11 scope per T008; the array
+  materialization in a loop is v10 scope.
+
+### A-4 — GetRandomIOExtensions materializes full directory tree for random pick
+
+- **File:** `DotExtensions/System/IO/GetRandomIOExtensions.cs`
+- **Line:** 111
+- **Current behavior:** `DirectoryInfo[] array = dirs.ToArray();` materializes
+  the entire filtered directory tree into a single array, only to pick one
+  random item via `Random.Shared.GetItems(array, 1)`.
+- **Proposed fix:** Use reservoir sampling or count-then-pick to avoid
+  materializing the full tree.
+- **Impact:** High. On large directory trees, allocates a huge array.
+- **Note:** By design for uniform random selection; document the allocation
+  cost or provide a lazy alternative.
+
+### A-5 — GetRandomIOExtensions triggers IO per drive for HasDirectories check
+
+- **File:** `DotExtensions/System/IO/GetRandomIOExtensions.cs`
+- **Lines:** 49-51
+- **Current behavior:** `DriveInfo.SafelyEnumerateLogicalDrives()
+  .Where(d => d.HasDirectories).ToArray()` — `HasDirectories` triggers
+  directory enumeration per drive.
+- **Proposed fix:** Combine filtering or cache the `HasDirectories` result.
+- **Impact:** Medium. Drive count is small but `HasDirectories` triggers IO.
+
+### A-6 — GetRandomIOExtensions materializes directories with HasFiles check
+
+- **File:** `DotExtensions/System/IO/GetRandomIOExtensions.cs`
+- **Lines:** 146-148
+- **Current behavior:** `.SafelyEnumerateDirectories().Where(d => d.HasFiles)
+  .ToArray()` — `HasFiles` triggers file enumeration per directory, then
+  materializes into array.
+- **Proposed fix:** Same as A-4; lazy approaches.
+- **Impact:** High. Each `HasFiles` triggers file enumeration.
+
+### A-7 — StringValuesIsNullExtensions allocates bool array for Any check
+
+- **File:** `DotExtensions/MsExtensions/Primitives/StringValuesIsNullExtensions.cs`
+- **Line:** 68
+- **Current behavior:** `bool[] vals = new bool[other.Count]` allocates a
+  boolean array, fills it, then uses `.Any(x => x)`. A simple loop with early
+  return would suffice.
+- **Proposed fix:** Replace with a direct loop:
+  `for (int i = 0; i < other.Count; i++)
+  { if (string.IsNullOrWhiteSpace(other[i])) return true; } return false;`
+- **Impact:** Low-Medium. Unnecessary array allocation.
+
+### A-8 — SegmentEnumerableToStringExtensions creates StringBuilder without capacity
+
+- **File:** `DotExtensions/MsExtensions/Primitives/Collections/SegmentEnumerableToStringExtensions.cs`
+- **Lines:** 48, 80
+- **Current behavior:** `StringBuilder stringBuilder = new();` without initial
+  capacity. Resizes multiple times as content is appended.
+- **Proposed fix:** Estimate capacity from segments (e.g., total length plus
+  separator overhead).
+- **Impact:** Low-Medium. StringBuilder resizing allocates intermediate char arrays.
+
+### A-9 — VersionParseExtensions.ParseChars creates StringBuilder without capacity
+
+- **File:** `DotExtensions/System/Versions/VersionParseExtensions.cs`
+- **Line:** 35
+- **Current behavior:** `StringBuilder stringBuilder = new();` without capacity.
+- **Proposed fix:** Use `new StringBuilder(chars.Length)`.
+- **Impact:** Low. Input is typically short; fix is trivial.
+
+### A-11 — VersionParseExtensions allocates StringBuilder inside loop
+
+- **File:** `DotExtensions/System/Versions/VersionParseExtensions.cs`
+- **Line:** 117
+- **Current behavior:** `StringBuilder stringBuilder = new(component.Length);`
+  allocated inside a `for` loop (up to 4 iterations).
+- **Proposed fix:** Reuse a single StringBuilder via `.Clear()` between uses,
+  or parse digits directly without StringBuilder.
+- **Impact:** Low. Only up to 4 small allocations.
+
+---
+
+## Category B: Boxing/Conversion Issues
+
+### B-1 — FileSizeExtensions uses string.Format with value type (boxing)
+
+- **File:** `DotExtensions/System/IO/FileSizeExtensions.cs`
+- **Line:** 50
+- **Current behavior:** `string.Format(...)` with `long quantity` parameter
+  causes boxing via `params object[]`.
+- **Proposed fix:** Use string interpolation:
+  `$"{quantity}{file.GetFileSizeUnitString()}"`. On .NET 6+, the interpolated
+  string handler avoids boxing.
+- **Impact:** Low. Single boxing; not in a tight loop.
+
+### B-2 — UnixPermissionParsingExtensions converts char to int via string
+
+- **File:** `DotExtensions/System/IO/Permissions/Unix/UnixPermissionParsingExtensions.cs`
+- **Lines:** 172-174
+- **Current behavior:** `int.Parse(notation.First().ToString(), ...)` extracts
+  a char, allocates a string via `.ToString()`, then parses back to int.
+  Three occurrences per call.
+- **Proposed fix:** Use `notation[0] - '0'` directly.
+- **Impact:** Low-Medium. Three string allocations per call; fix is trivial.
+
+### B-3 — NumberToTNumber converts via string round-trip
+
+- **File:** `DotExtensions/System/Numbers/NumberToTNumber.cs`
+- **Line:** 61
+- **Current behavior:** `TDestinationNumber.Parse(number.ToString(), ...)`
+  converts number to string then parses back. Used by all number-to-number
+  conversions.
+- **Proposed fix:** Use `TDestinationNumber.CreateChecked(number)` (available
+  in .NET 7+ with `INumber<T>`).
+- **Impact:** High. Core conversion method; string allocated on every call.
+
+### B-4 — CountDigitsExtensions calls string-round-trip conversion in loop
+
+- **File:** `DotExtensions/System/Numbers/CountDigitsExtensions.cs`
+- **Lines:** 49, 54
+- **Current behavior:** `(-1.ToNumber<TNumber>())` and
+  `(number /= 10.ToNumber<TNumber>())` call `ToNumber<TNumber>()` which uses
+  the string round-trip from B-3. The while loop calls `10.ToNumber<TNumber>()`
+  on every iteration.
+- **Proposed fix:** Cache converted constants outside the loop. Better: use
+  `TNumber.CreateChecked` to avoid string conversion entirely.
+- **Impact:** High. O(digits) string allocations per call.
+
+### B-5 — DateOnlyToDateTimeExtension converts via long date string
+
+- **File:** `DotExtensions/System/Dates/DateOnlyExtensions/DateOnlyToDateTimeExtension.cs`
+- **Line:** 44
+- **Current behavior:** `DateTime.Parse(dateOnly.ToLongDateString(), ...)`
+  converts to a culture-formatted date string then parses back.
+- **Proposed fix:** Use `new DateTime(dateOnly.Year, dateOnly.Month,
+  dateOnly.Day)` or `dateOnly.ToDateTime(TimeOnly.MinValue)`.
+- **Impact:** Medium. Allocates 30+ char string plus parsing overhead. Called
+  by multiple subtraction/difference extension methods.
+
+### B-6 — CapitalizationExtensions uses "N" format for index
+
+- **File:** `DotExtensions/System/Strings/Cases/CapitalizationExtensions.cs`
+- **Line:** 75
+- **Current behavior:** `index.ToString("N", CultureInfo.CurrentCulture)` uses
+  Number format with group separators for an index value.
+- **Proposed fix:** Use `index.ToString(CultureInfo.InvariantCulture)` or
+  `$"{index}"`.
+- **Impact:** Low. Error path only; semantically wrong format.
+
+### B-7 — SegmentCapitalizationExtensions uses "N" format for index
+
+- **File:** `DotExtensions/MsExtensions/Primitives/Cases/SegmentCapitalizationExtensions.cs`
+- **Line:** 77
+- **Current behavior:** Same as B-6.
+- **Proposed fix:** Same as B-6.
+- **Impact:** Low.
+
+### B-8 — StringValuesToStringExtensions interpolates separator in loop
+
+- **File:** `DotExtensions/MsExtensions/Primitives/StringValuesToStringExtensions.cs`
+- **Lines:** 57, 89
+- **Current behavior:** `stringBuilder.Append($"{separator}")` inside a
+  `foreach` loop allocates a new string per iteration when separator is a char.
+- **Proposed fix:** Use `stringBuilder.Append(separator)` directly.
+- **Impact:** Medium. One string allocation per entry in the loop.
+
+### B-9 — StringValuesToStringExtensions interpolates separator for EndsWith
+
+- **File:** `DotExtensions/MsExtensions/Primitives/StringValuesToStringExtensions.cs`
+- **Lines:** 63, 95
+- **Current behavior:** `output.EndsWith($"{separator}", ...)` allocates a
+  string for comparison.
+- **Proposed fix:** Use `output.EndsWith(separator, StringComparison.Ordinal)`
+  directly.
+- **Impact:** Low. Single allocation per call.
+
+### B-10 — SegmentCapitalizationExtensions allocates via string interpolation
+
+- **File:** `DotExtensions/MsExtensions/Primitives/Cases/SegmentCapitalizationExtensions.cs`
+- **Line:** 52
+- **Current behavior:** `$"{segment.Substring(0, index)}{char.ToUpper(c, ...)}
+  {segment.Substring(index + 1)}"` allocates 3+ strings (two Substrings +
+  interpolation result).
+- **Proposed fix:** Use `StringBuilder` with pre-allocated capacity.
+- **Impact:** Low-Medium.
+
+### B-11 — SegmentRemoveAndReplaceExtensions interpolates two segments
+
+- **File:** `DotExtensions/MsExtensions/Primitives/Removal/SegmentRemoveAndReplaceExtensions.cs`
+- **Line:** 81
+- **Current behavior:** `new StringSegment($"{firstSegment}{secondSegment}")`
+  allocates 2-3 strings.
+- **Proposed fix:** Use `StringBuilder` or compute from underlying buffer.
+- **Impact:** Low-Medium.
+
+### B-13 — ReadableVersionStringExtensions interpolation on older TFMs
+
+- **File:** `DotExtensions/System/Versions/ReadableVersionStringExtensions.cs`
+- **Lines:** 49, 53, 55
+- **Current behavior:** String interpolation with `int` value types. On .NET 6+
+  the interpolated string handler avoids boxing. On older TFMs (netstandard2.0),
+  this boxes each `int`.
+- **Proposed fix:** On older TFMs, use `.ToString(CultureInfo.InvariantCulture)`
+  concatenated with `.` literals.
+- **Impact:** Low. Multi-targeted; only affects older TFMs.
+
+### B-14 — ArgumentExceptionExtensions.SecureStrings allocates SecureString for comparison
+
+- **File:** `DotExtensions/System/Exceptions/ArgumentExceptionExtensions.SecureStrings.cs`
+- **Lines:** 73-78
+- **Current behavior:** `ThrowIfNullOrWhiteSpace` creates a new `SecureString`
+  and fills with spaces for comparison. `SecureString.Equals` uses reference
+  equality so the comparison always returns `false` — logic bug plus allocation.
+- **Proposed fix:** Iterate through the `SecureString` characters directly via
+  `Marshal.SecureStringToBSTR`, check each character, then free the BSTR.
+- **Impact:** Low-Medium. Expensive allocation plus logic bug.
+
+---
+
+## Summary Table
+
+| ID | Category | File (short) | Line(s) | Impact | v10 PR Scope |
+|----|----------|-------------|---------|--------|-------------|
+| A-1 | A | CharacterConstants.cs | 37 | Medium | Yes |
+| A-2 | A | ContainsSubstringsExtensions.cs | 52 | Medium | Yes |
+| A-3 | A | GetRandomIOExtensions.cs | 154-155 | High | Partial (array only) |
+| A-4 | A | GetRandomIOExtensions.cs | 111 | High | Yes |
+| A-5 | A | GetRandomIOExtensions.cs | 49-51 | Medium | Yes |
+| A-6 | A | GetRandomIOExtensions.cs | 146-148 | High | Partial (array only) |
+| A-7 | A | StringValuesIsNullExtensions.cs | 68 | Low-Med | Yes |
+| A-8 | A | SegmentEnumerableToStringExtensions.cs | 48, 80 | Low-Med | Yes |
+| A-9 | A | VersionParseExtensions.cs | 35 | Low | Yes |
+| A-11 | A | VersionParseExtensions.cs | 117 | Low | Yes |
+| B-1 | B | FileSizeExtensions.cs | 50 | Low | Yes |
+| B-2 | B | UnixPermissionParsingExtensions.cs | 172-174 | Low-Med | Yes |
+| B-3 | B | NumberToTNumber.cs | 61 | High | Yes |
+| B-4 | B | CountDigitsExtensions.cs | 49, 54 | High | Yes |
+| B-5 | B | DateOnlyToDateTimeExtension.cs | 44 | Medium | Yes |
+| B-6 | B | CapitalizationExtensions.cs | 75 | Low | Yes |
+| B-7 | B | SegmentCapitalizationExtensions.cs | 77 | Low | Yes |
+| B-8 | B | StringValuesToStringExtensions.cs | 57, 89 | Medium | Yes |
+| B-9 | B | StringValuesToStringExtensions.cs | 63, 95 | Low | Yes |
+| B-10 | B | SegmentCapitalizationExtensions.cs | 52 | Low-Med | Yes |
+| B-11 | B | SegmentRemoveAndReplaceExtensions.cs | 81 | Low-Med | Yes |
+| B-13 | B | ReadableVersionStringExtensions.cs | 49, 53, 55 | Low | Yes |
+| B-14 | B | ArgumentExceptionExtensions.SecureStrings.cs | 73-78 | Low-Med | Yes |
+
+## Top Priority Fixes (High Impact)
+
+1. **B-3 + B-4**: `NumberToTNumber` string round-trip used in
+   `CountDigitsExtensions` loop — O(digits) string allocations per call.
+2. **A-3, A-4, A-6**: `GetRandomIOExtensions` materializes large directory
+   trees into arrays inside loops.
+3. **A-1**: `CharacterConstants.EscapeCharacters` allocates on every access;
+   one-line fix.
+
+## References
+
+- Decision ledger: `DECISIONS-DotExtensions-performance-improvements.md#T008`
+- Decision ledger: `DECISIONS-DotExtensions-performance-improvements.md#D005`
+- Decision ledger: `DECISIONS-DotExtensions-performance-improvements.md#D006`

--- a/docs/decisions/POLYFILL-AUDIT-v10.md
+++ b/docs/decisions/POLYFILL-AUDIT-v10.md
@@ -1,0 +1,52 @@
+# Polyfill Content Audit — v10 Additive Span API
+
+## Purpose
+
+Audit of the `Polyfill` NuGet package (v10.11.2) coverage for each API the v10
+additive Span API (T007) needs on `netstandard2.0`. Each API is recorded as:
+**covered** (no action), **not covered** (work around in API design per D008),
+or **partially covered** (verify the specific overload).
+
+## Scope
+
+The additive Span API (T007) adds `Span<char>` and `ReadOnlySpan<char>` overloads
+for string extension methods in `DotExtensions.Memory`. The APIs required on
+`netstandard2.0` are listed below.
+
+## Audit Results
+
+| API | Coverage | Notes |
+|-----|----------|-------|
+| `GC.AllocateUninitializedArray<T>(int, bool)` | **Covered** | Confirmed in Polyfill API list (line 419 of api_list.include.md). |
+| `ArgumentOutOfRangeException.ThrowIfNegative<T>(T)` | **Covered** | Confirmed in Polyfill API list under ArgumentOutOfRangeException. |
+| `ArgumentOutOfRangeException.ThrowIfGreaterThan<T>(T, T)` | **Covered** | Confirmed in Polyfill API list under ArgumentOutOfRangeException. |
+| `ArgumentException.ThrowIfNullOrEmpty(string?)` | **Covered** | Confirmed in Polyfill API list under ArgumentException. Requires `<PolyArgumentExceptions>true</PolyArgumentExceptions>` (already set in DotExtensions.Memory.csproj). |
+| `Span<T>` / `ReadOnlySpan<T>` types | **Covered** | Provided by `System.Memory` package (already referenced for `netstandard2.0` in DotExtensions.Memory.csproj). |
+| `MemoryExtensions.IndexOf<T>(ReadOnlySpan<T>, ReadOnlySpan<T>)` | **Covered** | Provided by `System.Memory` package. |
+| `MemoryExtensions.AsSpan<T>(T[])` | **Covered** | Provided by `System.Memory` package. |
+| `string.AsSpan()` | **Covered** | Provided by `System.Memory` package. |
+| `StringBuilder` | **Covered** | Built-in to `netstandard2.0`. No polyfill needed. |
+| `string.IndexOf(string, int, StringComparison)` | **Covered** | Built-in to `netstandard2.0`. No polyfill needed. |
+| `string.Contains(string, StringComparison)` | **Covered** | Built-in to `netstandard2.0`. No polyfill needed. |
+
+## Escalations
+
+**None.** All APIs required by the v10 additive Span API are covered by the
+existing `Polyfill` package (v10.11.2) and/or the existing `System.Memory`
+package reference. No new polyfill package dependencies are required.
+
+## Out of Scope
+
+The following are explicitly out of scope for this audit per T009:
+
+- LINQ/enumerator allocation optimizations (deferred to v11 per T008).
+- async/await internal optimizations (deferred to v11 per T008).
+- Non-`char` Span types (e.g., `Span<byte>`) — not added in v10 per T007.
+- `ReadOnlyMemory<char>` overloads — not added in v10 per T007.
+
+## References
+
+- Polyfill package API list: https://github.com/SimonCropp/Polyfill/blob/main/api_list.include.md
+- Polyfill NuGet: https://www.nuget.org/packages/Polyfill/10.11.2
+- Decision ledger: `DECISIONS-DotExtensions-performance-improvements.md#D008`
+- Decision ledger: `DECISIONS-DotExtensions-performance-improvements.md#T009`

--- a/tickets/io/001-io-test-structure-refactoring.md
+++ b/tickets/io/001-io-test-structure-refactoring.md
@@ -1,0 +1,39 @@
+---
+title: IO Test Structure Refactoring
+classification: Independent
+blocked_by: []
+parent: TESTS_PRD.md
+---
+
+## Goal
+
+Move existing IO test files into their target subdirectories to match the PRD's prescribed directory structure, keeping the test suite organized as the IO test surface grows.
+
+## What to build
+
+Relocate two existing test files and update their namespaces:
+
+1. Move `DotExtensions.Tests/IO/FileSizeExtensionTests.cs` to `DotExtensions.Tests/IO/FileSize/FileSizeExtensionTests.cs` and update its namespace from `DotExtensions.Tests.IO` to `DotExtensions.Tests.IO.FileSize`.
+
+2. Move `DotExtensions.Tests/IO/UnixFileModeExtensionTests.cs` to `DotExtensions.Tests/IO/UnixFileMode/UnixFileModeExtensionTests.cs` and update its namespace from `DotExtensions.Tests.IO` to `DotExtensions.Tests.IO.UnixFileMode`.
+
+The target subdirectories (`IO/FileSize/`, `IO/UnixFileMode/`) already exist and are empty. Do not modify test logic or assertions — only paths and namespaces.
+
+## Acceptance criteria
+
+- [ ] `FileSizeExtensionTests.cs` is in `IO/FileSize/` with namespace `DotExtensions.Tests.IO.FileSize`
+- [ ] `UnixFileModeExtensionTests.cs` is in `IO/UnixFileMode/` with namespace `DotExtensions.Tests.IO.UnixFileMode`
+- [ ] All tests still pass after the move
+- [ ] No test logic or assertions were modified
+
+## Context pointers
+
+**Files**
+- `DotExtensions.Tests/IO/FileSizeExtensionTests.cs` — source file to move
+- `DotExtensions.Tests/IO/UnixFileModeExtensionTests.cs` — source file to move
+- `DotExtensions.Tests/IO/FileSize/` — target directory (exists, empty)
+- `DotExtensions.Tests/IO/UnixFileMode/` — target directory (exists, empty)
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/io/002-isdirectoryempty-tests.md
+++ b/tickets/io/002-isdirectoryempty-tests.md
@@ -1,0 +1,43 @@
+---
+title: IsDirectoryEmpty Tests
+classification: Independent
+blocked_by: []
+parent: TESTS_PRD.md
+---
+
+## Goal
+
+Add unit tests for `IsDirectoryEmptyExtensions` covering empty directories, non-empty directories, and non-existent directories, ensuring the extension behaves correctly as documented.
+
+## What to build
+
+Create `DotExtensions.Tests/IO/Directories/IsDirectoryEmptyTests.cs` testing `IsDirectoryEmptyExtensions` (`IsEmpty` and `HasFiles` extension properties on `DirectoryInfo`).
+
+Test scenarios:
+- Empty directory — verify `IsEmpty` returns true, `HasFiles` returns false
+- Non-empty directory — verify `IsEmpty` returns false, `HasFiles` returns true
+- Non-existent directory — verify `DirectoryNotFoundException` is thrown
+- Use temporary directories created via `Directory.CreateDirectory` or `Path.Combine(Path.GetTempPath(), ...)` with unique names
+- Clean up temporary directories after each test
+
+Follow existing test patterns: `[Test]` attribute, `async Task`, `await Assert.That(...)`. Use `[MethodDataSource]` for parameterized scenarios where appropriate (e.g., different directory states).
+
+## Acceptance criteria
+
+- [ ] Empty directory returns true from `IsEmpty` and false from `HasFiles`
+- [ ] Non-empty directory returns false from `IsEmpty` and true from `HasFiles`
+- [ ] Non-existent directory throws `DirectoryNotFoundException`
+- [ ] Temporary directories are cleaned up after test execution
+- [ ] Tests follow TUnit patterns (`[Test]`, `async Task`, `await Assert.That(...)`)
+- [ ] Tests pass on all target frameworks (net8.0, net9.0, net10.0)
+
+## Context pointers
+
+**Files**
+- `DotExtensions/System/IO/Directories/IsDirectoryEmptyExtensions.cs` — source extension to test
+- `DotExtensions.Tests/IO/Directories/` — target directory (exists, empty)
+- `DotExtensions.Tests/IO/SafeEnumeration/SafeFileEnumerationTests.cs` — pattern for IO tests involving file system
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/ms-extensions/003-segment-conversion-tests.md
+++ b/tickets/ms-extensions/003-segment-conversion-tests.md
@@ -1,0 +1,56 @@
+---
+title: Segment Conversion Tests
+classification: Independent
+blocked_by: []
+parent: TESTS_PRD.md
+---
+
+## Goal
+
+Add unit tests for `AsStringSegmentsExtensions`, `SegmentReverseExtensions`, and `SegmentToCharsExtensions` to verify StringSegment-to-enumerable conversion, reversal, and character-array/list conversion.
+
+## What to build
+
+Create test files in `DotExtensions.Tests/MsExtensions/Primitives/`:
+
+1. **`AsStringSegmentsTests.cs`** — Test `AsStringSegments(this StringSegment)` which splits a StringSegment by whitespace into `IEnumerable<StringSegment>`. Cover:
+   - Normal sentence (multiple words)
+   - Single word (no split)
+   - Empty StringSegment
+   - Whitespace-only StringSegment
+   - Leading/trailing whitespace
+
+2. **`SegmentReverseTests.cs`** — Test `Reverse(this StringSegment)` which returns a reversed string. Cover:
+   - Normal string reversal
+   - Single character (reversal is identity)
+   - Empty StringSegment
+   - Null StringSegment (should throw `ArgumentNullException`)
+
+3. **`SegmentToCharsTests.cs`** — Test `ToCharArray(this StringSegment)` and `ToList(this StringSegment)`. Cover:
+   - Conversion of non-empty StringSegment to char array and char list
+   - Empty StringSegment
+   - Null StringSegment (should throw `ArgumentNullException`)
+
+Follow existing patterns: `[Test]`, `async Task`, `await Assert.That(...)`, `[MethodDataSource]` for parameterized data. Use `using Microsoft.Extensions.Primitives;` and `using DotExtensions.MsExtensions.Primitives;`.
+
+## Acceptance criteria
+
+- [ ] `AsStringSegments` splits correctly for normal, single-word, empty, and whitespace-only segments
+- [ ] `Reverse` returns correct reversed string for normal, single-char, and empty segments
+- [ ] `Reverse` throws `ArgumentNullException` for null segment
+- [ ] `ToCharArray` and `ToList` return correct results for non-empty and empty segments
+- [ ] `ToCharArray` and `ToList` throw `ArgumentNullException` for null segment
+- [ ] All tests pass on all target frameworks (net8.0, net9.0, net10.0)
+
+## Context pointers
+
+**Files**
+- `DotExtensions/MsExtensions/Primitives/AsStringSegmentsExtensions.cs` — source
+- `DotExtensions/MsExtensions/Primitives/SegmentReverseExtensions.cs` — source
+- `DotExtensions/MsExtensions/Primitives/SegmentToCharsExtensions.cs` — source
+- `DotExtensions.Tests/MsExtensions/Primitives/` — target directory
+- `DotExtensions.Tests/Strings/EscapeCharacters/EscapeCharacterRemovalTests.cs` — pattern for string manipulation tests
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/ms-extensions/004-segmentisnull-tests.md
+++ b/tickets/ms-extensions/004-segmentisnull-tests.md
@@ -1,0 +1,39 @@
+---
+title: SegmentIsNull Tests
+classification: Independent
+blocked_by: []
+parent: TESTS_PRD.md
+---
+
+## Goal
+
+Add unit tests for `SegmentIsNullExtensions` to verify correct detection of null, empty, and whitespace-only StringSegment values.
+
+## What to build
+
+Create `DotExtensions.Tests/MsExtensions/Primitives/SegmentIsNullTests.cs` testing `IsEmpty(this StringSegment?)`, `IsNullOrEmpty(this StringSegment?)`, and `IsNullOrWhiteSpace(this StringSegment?)`.
+
+Test scenarios:
+- `IsEmpty` — default StringSegment (empty), StringSegment with content, null StringSegment
+- `IsNullOrEmpty` — null, empty, whitespace-only, and non-empty StringSegment values
+- `IsNullOrWhiteSpace` — null, empty, whitespace-only, and non-empty StringSegment values
+- Edge: StringSegment with a single whitespace character
+
+Follow existing patterns: `[Test]`, `async Task`, `await Assert.That(...)`. Use `[MethodDataSource]` for parameterized data covering combinations of null/empty/whitespace/non-empty.
+
+## Acceptance criteria
+
+- [ ] `IsEmpty` returns true for default/empty StringSegment and false for non-empty segments
+- [ ] `IsNullOrEmpty` returns true for null and empty segments, false for whitespace-only and non-empty
+- [ ] `IsNullOrWhiteSpace` returns true for null, empty, and whitespace-only segments, false for non-empty
+- [ ] All tests pass on all target frameworks (net8.0, net9.0, net10.0)
+
+## Context pointers
+
+**Files**
+- `DotExtensions/MsExtensions/Primitives/SegmentIsNullExtensions.cs` — source
+- `DotExtensions.Tests/MsExtensions/Primitives/` — target directory
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/ms-extensions/005-segmentcase-tests.md
+++ b/tickets/ms-extensions/005-segmentcase-tests.md
@@ -1,0 +1,42 @@
+---
+title: SegmentCase Tests
+classification: Independent
+blocked_by: []
+parent: TESTS_PRD.md
+---
+
+## Goal
+
+Add unit tests for `SegmentCaseExtensions` to verify case detection on StringSegment values (IsUpperCase, IsLowerCase).
+
+## What to build
+
+Create `DotExtensions.Tests/MsExtensions/Primitives/Cases/SegmentCaseTests.cs` testing `IsUpperCase(this StringSegment)` and `IsLowerCase(this StringSegment)`.
+
+Test scenarios:
+- All-uppercase string (e.g., "HELLO") — IsUpperCase true, IsLowerCase false
+- All-lowercase string (e.g., "hello") — IsUpperCase false, IsLowerCase true
+- Mixed case (e.g., "Hello") — both false
+- Empty StringSegment — both false (or define expected behavior)
+- Null StringSegment — should throw `ArgumentNullException`
+- Strings with non-letter characters (digits, symbols) — define expected behavior
+
+Follow existing patterns: `[Test]`, `async Task`, `await Assert.That(...)`, `[MethodDataSource]` for parameterized data.
+
+## Acceptance criteria
+
+- [ ] `IsUpperCase` returns true for all-uppercase, false for mixed/lowercase/empty
+- [ ] `IsLowerCase` returns true for all-lowercase, false for mixed/uppercase/empty
+- [ ] Both methods throw `ArgumentNullException` for null StringSegment
+- [ ] All tests pass on all target frameworks (net8.0, net9.0, net10.0)
+
+## Context pointers
+
+**Files**
+- `DotExtensions/MsExtensions/Primitives/Cases/SegmentCaseExtensions.cs` — source
+- `DotExtensions.Tests/MsExtensions/Primitives/Cases/` — target directory (exists, empty)
+- `DotExtensions.Tests/Strings/Cases/CapitalizationTests.cs` — pattern for case-related tests
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/ms-extensions/006-segmentcapitalization-tests.md
+++ b/tickets/ms-extensions/006-segmentcapitalization-tests.md
@@ -1,0 +1,48 @@
+---
+title: SegmentCapitalization Tests
+classification: Independent
+blocked_by: []
+parent: TESTS_PRD.md
+---
+
+## Goal
+
+Add unit tests for `SegmentCapitalizationExtensions` to verify character-level capitalization on StringSegment values (CapitalizeChar, CapitalizeChars).
+
+## What to build
+
+Create `DotExtensions.Tests/MsExtensions/Primitives/Cases/SegmentCapitalizationTests.cs` testing `CapitalizeChar(this StringSegment, int index)` and `CapitalizeChars(this StringSegment, int startIndex, int length)`.
+
+Test scenarios:
+- CapitalizeChar: capitalize first character, middle character, last character
+- CapitalizeChar: null segment throws `ArgumentNullException`
+- CapitalizeChar: out-of-range index (negative, beyond length)
+- CapitalizeChars: capitalize a range in the middle
+- CapitalizeChars: null segment throws `ArgumentNullException`
+- CapitalizeChars: invalid startIndex or length (negative, beyond bounds)
+- CapitalizeChars: empty StringSegment
+- CapitalizeChars: range covering the entire segment
+- Edge cases: indices at boundaries (0, length-1, length)
+
+Follow existing patterns: `[Test]`, `async Task`, `await Assert.That(...)`, `[MethodDataSource]` for parameterized data covering index/length boundaries.
+
+## Acceptance criteria
+
+- [ ] `CapitalizeChar` correctly capitalizes the character at the given index
+- [ ] `CapitalizeChar` throws `ArgumentNullException` for null segment
+- [ ] `CapitalizeChar` throws appropriate exception for out-of-range index
+- [ ] `CapitalizeChars` correctly capitalizes the specified range
+- [ ] `CapitalizeChars` throws `ArgumentNullException` for null segment
+- [ ] `CapitalizeChars` throws appropriate exception for invalid bounds
+- [ ] All tests pass on all target frameworks (net8.0, net9.0, net10.0)
+
+## Context pointers
+
+**Files**
+- `DotExtensions/MsExtensions/Primitives/Cases/SegmentCapitalizationExtensions.cs` — source
+- `DotExtensions.Tests/MsExtensions/Primitives/Cases/` — target directory (exists, empty)
+- `DotExtensions.Tests/Strings/Cases/CapitalizationTests.cs` — pattern for similar capitalization tests
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/ms-extensions/007-segmentcontains-tests.md
+++ b/tickets/ms-extensions/007-segmentcontains-tests.md
@@ -1,0 +1,53 @@
+---
+title: SegmentContains Tests
+classification: Independent
+blocked_by: []
+parent: TESTS_PRD.md
+---
+
+## Goal
+
+Add unit tests for `SegmentContainsExtensions` and `SegmentContainsSubsegmentsExtensions` to verify substring and delimited-subsegment detection on StringSegment values.
+
+## What to build
+
+Create test files in `DotExtensions.Tests/MsExtensions/Primitives/Contains/`:
+
+1. **`SegmentContainsTests.cs`** — Test `Contains(this StringSegment, char)` and `Contains(this StringSegment, StringSegment)`. Cover:
+   - Char present / not present in segment
+   - Substring present / not present
+   - Case sensitivity behavior
+   - Empty segment
+   - Null segment (throws `ArgumentNullException`)
+   - Null search value
+
+2. **`SegmentContainsSubsegmentsTests.cs`** — Test `ContainsDelimitedSubSegments(this StringSegment, char delimiter, StringSegment subSegment)`. Cover:
+   - Subsegment found / not found in delimited segment
+   - Different delimiters (comma, pipe, space, etc.)
+   - Subsegment at start, middle, end of delimited list
+   - Empty segment or empty delimiter
+   - Null segment (throws `ArgumentNullException`)
+
+Follow existing patterns: `[Test]`, `async Task`, `await Assert.That(...)`, `[MethodDataSource]` for parameterized data.
+
+## Acceptance criteria
+
+- [ ] `Contains(char)` returns true/false correctly for present/absent characters
+- [ ] `Contains(StringSegment)` returns true/false correctly for present/absent substrings
+- [ ] `Contains` throws `ArgumentNullException` for null segment
+- [ ] `ContainsDelimitedSubSegments` correctly finds subsegments in delimited strings
+- [ ] `ContainsDelimitedSubSegments` handles subsegment at any position in the delimited list
+- [ ] `ContainsDelimitedSubSegments` throws `ArgumentNullException` for null segment
+- [ ] All tests pass on all target frameworks (net8.0, net9.0, net10.0)
+
+## Context pointers
+
+**Files**
+- `DotExtensions/MsExtensions/Primitives/Contains/SegmentContainsExtensions.cs` — source
+- `DotExtensions/MsExtensions/Primitives/Contains/SegmentContainsSubsegmentsExtensions.cs` — source
+- `DotExtensions.Tests/MsExtensions/Primitives/Contains/` — target directory (exists, empty)
+- `DotExtensions.Tests/Strings/Contains/ContainsSpacesTests.cs` — pattern for contains tests
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/ms-extensions/008-segmentremoveandreplace-tests.md
+++ b/tickets/ms-extensions/008-segmentremoveandreplace-tests.md
@@ -1,0 +1,48 @@
+---
+title: SegmentRemoveAndReplace Tests
+classification: Independent
+blocked_by: []
+parent: TESTS_PRD.md
+---
+
+## Goal
+
+Add unit tests for `SegmentRemoveAndReplaceExtensions` to verify all Remove overloads on StringSegment values handle boundaries, nulls, and edge cases correctly.
+
+## What to build
+
+Create `DotExtensions.Tests/MsExtensions/Primitives/Removal/SegmentRemoveAndReplaceTests.cs` testing the Remove overloads on StringSegment.
+
+Test scenarios:
+- Remove at specific index with length
+- Remove all instances of a character
+- Remove all instances of a substring
+- Remove from start index to end
+- Null segment throws `ArgumentNullException`
+- Out-of-range indices (negative, beyond length)
+- Zero-length removal (no-op)
+- Removal at boundaries (index 0, index at length-1)
+- Replace character/substring with another
+- No-op cases (character/substring not found)
+- Empty segment
+
+Follow existing patterns: `[Test]`, `async Task`, `await Assert.That(...)`, `[MethodDataSource]` for parameterized data.
+
+## Acceptance criteria
+
+- [ ] All Remove overloads produce correct results for valid inputs
+- [ ] All Remove overloads throw `ArgumentNullException` for null segment
+- [ ] Out-of-range indices produce appropriate exceptions
+- [ ] Empty segment cases are handled correctly
+- [ ] All tests pass on all target frameworks (net8.0, net9.0, net10.0)
+
+## Context pointers
+
+**Files**
+- `DotExtensions/MsExtensions/Primitives/Removal/SegmentRemoveAndReplaceExtensions.cs` — source
+- `DotExtensions.Tests/MsExtensions/Primitives/Removal/` — target directory (need to create)
+- `DotExtensions.Tests/Strings/EscapeCharacters/EscapeCharacterRemovalTests.cs` — pattern for removal tests
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/ms-extensions/009-segmentenumerabletostring-tests.md
+++ b/tickets/ms-extensions/009-segmentenumerabletostring-tests.md
@@ -1,0 +1,44 @@
+---
+title: SegmentEnumerableToString Tests
+classification: Independent
+blocked_by: []
+parent: TESTS_PRD.md
+---
+
+## Goal
+
+Add unit tests for `SegmentEnumerableToStringExtensions` to verify conversion of StringSegment enumerables to delimited strings handles delimiters, empty collections, and edge cases.
+
+## What to build
+
+Create `DotExtensions.Tests/MsExtensions/Primitives/Collections/SegmentEnumerableToStringTests.cs` testing `ToString(this IEnumerable<StringSegment>, char)` and `ToString(this IEnumerable<StringSegment>, string)`.
+
+Test scenarios:
+- Multiple segments joined with char delimiter
+- Multiple segments joined with string delimiter
+- Single-element collection
+- Empty collection (returns empty string)
+- Null collection (throws `ArgumentNullException`)
+- Segments containing the delimiter character
+- Large number of segments
+- Delimiters of various types (comma, pipe, newline)
+
+Follow existing patterns: `[Test]`, `async Task`, `await Assert.That(...)`, `[MethodDataSource]` for parameterized data.
+
+## Acceptance criteria
+
+- [ ] Segments are joined correctly with char delimiter
+- [ ] Segments are joined correctly with string delimiter
+- [ ] Empty collection returns empty string
+- [ ] Null collection throws `ArgumentNullException`
+- [ ] All tests pass on all target frameworks (net8.0, net9.0, net10.0)
+
+## Context pointers
+
+**Files**
+- `DotExtensions/MsExtensions/Primitives/Collections/SegmentEnumerableToStringExtensions.cs` — source
+- `DotExtensions.Tests/MsExtensions/Primitives/Collections/` — target directory (exists, empty)
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/ms-extensions/010-stringvalues-operations-tests.md
+++ b/tickets/ms-extensions/010-stringvalues-operations-tests.md
@@ -1,0 +1,55 @@
+---
+title: StringValues Operations Tests
+classification: Independent
+blocked_by: []
+parent: TESTS_PRD.md
+---
+
+## Goal
+
+Add unit tests for `StringValuesToStringExtensions`, `StringValuesLengthExtensions`, and `StringValuesIsNullExtensions` to verify StringValues conversion, total length computation, and null/empty detection.
+
+## What to build
+
+Create test files in `DotExtensions.Tests/MsExtensions/Primitives/StringValues/`:
+
+1. **`StringValuesToStringTests.cs`** — Test `ToString(this StringValues, char)` and `ToString(this StringValues, string)` which join values with a delimiter. Cover:
+   - Single-value StringValues
+   - Multi-value StringValues
+   - Empty StringValues
+   - Null StringValues
+   - Char and string delimiters
+
+2. **`StringValuesLengthTests.cs`** — Test `TotalLength` property. Cover:
+   - Single-value StringValues (length of the value)
+   - Multi-value StringValues (sum of all value lengths)
+   - Empty StringValues (total length 0)
+   - Null StringValues
+
+3. **`StringValuesIsNullTests.cs`** — Test `IsEmpty(this StringValues?)` and `IsNullOrWhiteSpace(this StringValues?)`. Cover:
+   - Null, empty, whitespace-only, and non-empty StringValues
+   - Single value that is whitespace
+   - Multiple values where some are empty
+
+Follow existing patterns: `[Test]`, `async Task`, `await Assert.That(...)`, `[MethodDataSource]` for parameterized data.
+
+## Acceptance criteria
+
+- [ ] `ToString(char)` and `ToString(string)` produce correct joined output
+- [ ] `ToString` on empty/null StringValues returns expected empty string
+- [ ] `TotalLength` returns correct character count for all cases
+- [ ] `IsEmpty` returns true for empty/null, false for non-empty StringValues
+- [ ] `IsNullOrWhiteSpace` returns true for null/empty/whitespace, false for non-empty
+- [ ] All tests pass on all target frameworks (net8.0, net9.0, net10.0)
+
+## Context pointers
+
+**Files**
+- `DotExtensions/MsExtensions/Primitives/StringValuesToStringExtensions.cs` — source
+- `DotExtensions/MsExtensions/Primitives/StringValuesLengthExtensions.cs` — source
+- `DotExtensions/MsExtensions/Primitives/StringValuesIsNullExtensions.cs` — source
+- `DotExtensions.Tests/MsExtensions/Primitives/StringValues/` — target directory (needs creation)
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/ms-extensions/011-argumentexception-segment-tests.md
+++ b/tickets/ms-extensions/011-argumentexception-segment-tests.md
@@ -1,0 +1,42 @@
+---
+title: ArgumentExceptionStringSegment Tests
+classification: Independent
+blocked_by: []
+parent: TESTS_PRD.md
+---
+
+## Goal
+
+Add unit tests for `ArgumentExceptionStringSegmentExtensions` to verify argument validation on StringSegment parameters throws correct exceptions.
+
+## What to build
+
+Create `DotExtensions.Tests/MsExtensions/Primitives/Exceptions/ArgumentExceptionStringSegmentTests.cs` testing `ThrowIfNullOrEmpty(this ArgumentException, StringSegment)` and `ThrowIfNullOrWhitespace(this ArgumentException, StringSegment)`.
+
+Test scenarios:
+- Non-null, non-empty segment — no exception thrown
+- Null segment — throws `ArgumentNullException`
+- Empty segment — throws `ArgumentException` (or appropriate derived type)
+- Whitespace-only segment — throws `ArgumentException` for ThrowIfNullOrWhitespace
+- Verify exception messages are non-empty and descriptive
+
+Follow existing patterns: `[Test]`, `async Task`, `await Assert.That(...)`, `await Assert.ThrowsAsync<T>(...)`.
+
+## Acceptance criteria
+
+- [ ] `ThrowIfNullOrEmpty` passes for non-null, non-empty segment
+- [ ] `ThrowIfNullOrEmpty` throws for null segment
+- [ ] `ThrowIfNullOrEmpty` throws for empty segment
+- [ ] `ThrowIfNullOrWhitespace` passes for non-null, non-empty, non-whitespace segment
+- [ ] `ThrowIfNullOrWhitespace` throws for null, empty, and whitespace-only segments
+- [ ] All tests pass on all target frameworks (net8.0, net9.0, net10.0)
+
+## Context pointers
+
+**Files**
+- `DotExtensions/MsExtensions/Primitives/Exceptions/ArgumentExceptionStringSegmentExtensions.cs` — source
+- `DotExtensions.Tests/MsExtensions/Primitives/Exceptions/` — target directory (needs creation)
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/ms-extensions/012-argumentexception-stringvalues-tests.md
+++ b/tickets/ms-extensions/012-argumentexception-stringvalues-tests.md
@@ -1,0 +1,41 @@
+---
+title: ArgumentExceptionStringValues Tests
+classification: Independent
+blocked_by: []
+parent: TESTS_PRD.md
+---
+
+## Goal
+
+Add unit tests for `ArgumentExceptionStringValuesExtensions` to verify argument validation on StringValues parameters throws correct exceptions.
+
+## What to build
+
+Create `DotExtensions.Tests/MsExtensions/Primitives/Exceptions/ArgumentExceptionStringValuesTests.cs` testing `ThrowIfNullOrEmpty(this ArgumentException, StringValues)` and `ThrowIfNullOrWhiteSpace(this ArgumentException, StringValues)`.
+
+Test scenarios:
+- Non-null, non-empty StringValues — no exception thrown
+- Null StringValues — throws `ArgumentNullException`
+- Empty StringValues — throws `ArgumentException` (or appropriate derived type)
+- Whitespace-only StringValues — throws `ArgumentException` for ThrowIfNullOrWhiteSpace
+- Verify exception messages are non-empty and descriptive
+
+Follow existing patterns: `[Test]`, `async Task`, `await Assert.That(...)`, `await Assert.ThrowsAsync<T>(...)`.
+
+## Acceptance criteria
+
+- [ ] `ThrowIfNullOrEmpty` passes for non-null, non-empty StringValues
+- [ ] `ThrowIfNullOrEmpty` throws for null and empty StringValues
+- [ ] `ThrowIfNullOrWhitespace` passes for non-null, non-empty, non-whitespace StringValues
+- [ ] `ThrowIfNullOrWhitespace` throws for null, empty, and whitespace-only StringValues
+- [ ] All tests pass on all target frameworks (net8.0, net9.0, net10.0)
+
+## Context pointers
+
+**Files**
+- `DotExtensions/MsExtensions/Primitives/Exceptions/ArgumentExceptionStringValuesExtensions.cs` — source
+- `DotExtensions.Tests/MsExtensions/Primitives/Exceptions/` — target directory (needs creation)
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/perf/additive-span/005-polyfill-content-audit.md
+++ b/tickets/perf/additive-span/005-polyfill-content-audit.md
@@ -1,0 +1,83 @@
+---
+title: Additive Span - polyfill content audit
+classification: Independent
+blocked_by: []
+parent: docs/decisions/DECISIONS-DotExtensions-performance-improvements.md
+---
+
+## Goal
+
+Document an audit of the `Polyfill` NuGet package coverage for each API the v10 additive Span API needs on `netstandard2.0`, recording each API as covered, not covered, or partially covered, and escalating any gap that would require a new polyfill package.
+
+## What to build
+
+Read the `Polyfill` NuGet package documentation and verify coverage of each API the additive Span API (ticket 6) needs on `netstandard2.0`. The audit records each API as: covered (no action), not covered (work around in API design per D008), or partially covered (verify the specific overload). Any gap requiring a new polyfill package is escalated per D008.
+
+## Recommended Workflow
+
+### Step 1 — Read the Polyfill NuGet package documentation
+
+Where: N/A
+
+- Read the `Polyfill` NuGet package documentation to understand the API surface it covers
+- Note which APIs are polyfilled for `netstandard2.0`
+
+Verify: N/A
+
+### Step 2 — List each API the additive Span API needs on netstandard2.0
+
+Where: N/A
+
+- List each API the additive Span API (ticket 6) needs on `netstandard2.0`
+- Include `GC.AllocateUninitializedArray` and any other modern APIs
+
+Verify: N/A
+
+### Step 3 — For each API, verify coverage
+
+Where: N/A
+
+- For each API, verify coverage: covered, not covered, or partially covered
+- Note any gaps
+
+Verify: N/A
+
+### Step 4 — Document the audit results in a markdown file
+
+Where: `docs/decisions/POLYFILL-AUDIT-v10.md`
+
+- Create a markdown file documenting the audit results
+- Record each API as covered, not covered, or partially covered
+
+Verify: Audit document is created
+
+### Step 5 — Escalate any gap that would require a new polyfill package per D008
+
+Where: N/A
+
+- If any gap requires a new polyfill package, escalate per D008
+- Document the escalation in the audit file
+
+Verify: Gaps are escalated or documented
+
+## Context pointers
+
+**Files**
+- `DotExtensions.Memory/DotExtensions.Memory.csproj` — Memory package project
+- `DotExtensions.Memory/Polyfills/ReadOnlyMemorySort.cs` — existing polyfill file
+
+**Ledger records**
+- `DECISIONS-DotExtensions-performance-improvements.md#T007` — additive Span API surface
+- `DECISIONS-DotExtensions-performance-improvements.md#T009` — polyfill content audit
+- `DECISIONS-DotExtensions-performance-improvements.md#D008` — v10 polyfill strategy
+
+## Acceptance criteria
+
+- [ ] Each API the additive Span API needs on `netstandard2.0` is recorded as covered, not covered, or partially covered (per `DECISIONS-DotExtensions-performance-improvements.md#T009`)
+- [ ] No new polyfill package dependencies are added in v10 (per `DECISIONS-DotExtensions-performance-improvements.md#D008`)
+- [ ] Any gap requiring a new polyfill package is escalated per D008 (per `DECISIONS-DotExtensions-performance-improvements.md#D008`)
+- [ ] The audit results are documented in a markdown file (per `DECISIONS-DotExtensions-performance-improvements.md#T009`)
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/perf/additive-span/006-additive-span-char-removeall.md
+++ b/tickets/perf/additive-span/006-additive-span-char-removeall.md
@@ -1,0 +1,94 @@
+---
+title: Additive Span - Span<char>.RemoveAll additive overload
+classification: Independent
+blocked_by: [5]
+parent: docs/decisions/DECISIONS-DotExtensions-performance-improvements.md
+---
+
+## Goal
+
+Add a `ref Span<char>.RemoveAll` extension method in `DotExtensions.Memory` that returns the new length after removal, mirroring the documented contract of the main package's `string.RemoveAll`.
+
+## What to build
+
+Add a C# 14 extension method on `ref Span<char>` with signature `(ReadOnlySpan<char> value, StringComparison stringComparison = StringComparison.CurrentCulture)` returning `int` (the new length of the span after removal). It throws `ArgumentException` when `value` is empty. The behavior mirrors the documented contract of the main package's `string.RemoveAll` per D006.
+
+## Recommended Workflow
+
+### Step 1 — Read the polyfill audit results from ticket 5
+
+Where: `docs/decisions/POLYFILL-AUDIT-v10.md`
+
+- Read the audit results to confirm no gaps
+- Note any workarounds needed
+
+Verify: N/A
+
+### Step 2 — Read the string.RemoveAll XML doc comments
+
+Where: `DotExtensions/System/Strings/Removal/StringRemoveExtensions.cs`
+
+- Read the XML doc comments for `string.RemoveAll` to understand the documented contract
+- Note the exception types and parameter validation
+
+Verify: N/A
+
+### Step 3 — Create a new file in DotExtensions.Memory for the Span<char>.RemoveAll extension method
+
+Where: `DotExtensions.Memory/`
+
+- Create a new file for the `Span<char>.RemoveAll` extension method
+- Use the C# 14 extension method syntax
+
+Verify: `dotnet build DotExtensions.Memory -c Release` succeeds
+
+### Step 4 — Implement the method with signature (ReadOnlySpan<char> value, StringComparison stringComparison = StringComparison.CurrentCulture) returning int
+
+Where: `DotExtensions.Memory/`
+
+- Implement the method with the specified signature
+- Throw `ArgumentException` when `value` is empty
+- Mirror the documented contract of `string.RemoveAll`
+
+Verify: `dotnet build DotExtensions.Memory -c Release` succeeds
+
+### Step 5 — Verify the existing AOT build passes
+
+Where: `DotExtensions.AotTests/DotExtensions.AotTests.csproj`
+
+- Run `dotnet build DotExtensions.AotTests -c Release`
+- Confirm no new AOT warnings are introduced
+
+Verify: AOT build succeeds with no new warnings
+
+## Context pointers
+
+**Files**
+- `DotExtensions.Memory/DotExtensions.Memory.csproj` — Memory package project
+- `DotExtensions/System/Strings/Removal/StringRemoveExtensions.cs` — source file for contract reference
+
+**Ledger records**
+- `DECISIONS-DotExtensions-performance-improvements.md#T007` — additive Span API surface
+- `DECISIONS-DotExtensions-performance-improvements.md#T010` — Span<char>.RemoveAll type design
+- `DECISIONS-DotExtensions-performance-improvements.md#D002` — package layout (Memory separate)
+- `DECISIONS-DotExtensions-performance-improvements.md#D003` — v10/v11 perf strategy
+- `DECISIONS-DotExtensions-performance-improvements.md#D005` — v10 vs v11 scope allocation
+- `DECISIONS-DotExtensions-performance-improvements.md#D006` — bug standard for v10 behavior changes
+- `DECISIONS-DotExtensions-performance-improvements.md#D007` — v10 sequencing
+- `DECISIONS-DotExtensions-performance-improvements.md#D008` — v10 polyfill strategy
+- `DECISIONS-DotExtensions-performance-improvements.md#D009` — v10 test coverage expectations
+- `DECISIONS-DotExtensions-performance-improvements.md#D010` — v10 AOT compatibility expectations
+- `DECISIONS-DotExtensions-performance-improvements.md#D004` — v10 validation methodology
+
+## Acceptance criteria
+
+- [ ] The method is a C# 14 extension on `ref Span<char>` with signature `(ReadOnlySpan<char> value, StringComparison stringComparison = StringComparison.CurrentCulture)` returning `int` (per `DECISIONS-DotExtensions-performance-improvements.md#T010`)
+- [ ] The method throws `ArgumentException` when `value` is empty (per `DECISIONS-DotExtensions-performance-improvements.md#T010`)
+- [ ] The behavior mirrors the documented contract of `string.RemoveAll` per D006 (per `DECISIONS-DotExtensions-performance-improvements.md#D006`)
+- [ ] The method is in `DotExtensions.Memory`, not the main package (per `DECISIONS-DotExtensions-performance-improvements.md#D002`)
+- [ ] No new polyfill package dependencies are added (per `DECISIONS-DotExtensions-performance-improvements.md#D008`)
+- [ ] Existing AOT build passes with no new warnings (per `DECISIONS-DotExtensions-performance-improvements.md#D010`)
+
+## Dependencies
+
+**Blocked by** — 5. Requires the polyfill audit from ticket 5 to confirm no gaps.

--- a/tickets/perf/additive-span/007-additive-span-char-removeall-tests.md
+++ b/tickets/perf/additive-span/007-additive-span-char-removeall-tests.md
@@ -1,0 +1,76 @@
+---
+title: Additive Span - Span<char>.RemoveAll tests (public API + AOT runtime)
+classification: Independent
+blocked_by: [6]
+parent: docs/decisions/DECISIONS-DotExtensions-performance-improvements.md
+---
+
+## Goal
+
+Add a public API test for `Span<char>.RemoveAll` that exercises the API as a consumer would, and an AOT runtime test in `DotExtensions.AotTests` that exercises the public API under NativeAOT.
+
+## What to build
+
+Add a public API test in `DotExtensions.Tests` that exercises `Span<char>.RemoveAll` as a consumer would, asserting the documented contract. Add an AOT runtime test in `DotExtensions.AotTests` that exercises the public API under NativeAOT.
+
+## Recommended Workflow
+
+### Step 1 — Read the Span<char>.RemoveAll XML doc comments
+
+Where: `DotExtensions.Memory/`
+
+- Read the XML doc comments for `Span<char>.RemoveAll` to understand the documented contract
+- Note the exception types and parameter validation
+
+Verify: N/A
+
+### Step 2 — Create a public API test in DotExtensions.Tests
+
+Where: `DotExtensions.Tests/`
+
+- Create a public API test that exercises `Span<char>.RemoveAll` as a consumer would
+- Assert the documented contract
+
+Verify: `dotnet test DotExtensions.Tests` passes
+
+### Step 3 — Create an AOT runtime test in DotExtensions.AotTests
+
+Where: `DotExtensions.AotTests/`
+
+- Create an AOT runtime test that exercises the public API under NativeAOT
+- Mirror the public API test
+
+Verify: `dotnet test DotExtensions.AotTests` passes
+
+### Step 4 — Verify both tests pass
+
+Where: N/A
+
+- Run the full test suite
+- Confirm both tests pass
+
+Verify: `dotnet test` passes
+
+## Context pointers
+
+**Files**
+- `DotExtensions.Tests/DotExtensions.Tests.csproj` — test project
+- `DotExtensions.AotTests/DotExtensions.AotTests.csproj` — AOT test project
+- `DotExtensions.Memory/DotExtensions.Memory.csproj` — Memory package project
+
+**Ledger records**
+- `DECISIONS-DotExtensions-performance-improvements.md#T007` — additive Span API surface
+- `DECISIONS-DotExtensions-performance-improvements.md#T010` — Span<char>.RemoveAll type design
+- `DECISIONS-DotExtensions-performance-improvements.md#D004` — v10 validation methodology
+- `DECISIONS-DotExtensions-performance-improvements.md#D009` — v10 test coverage expectations
+- `DECISIONS-DotExtensions-performance-improvements.md#D010` — v10 AOT compatibility expectations
+
+## Acceptance criteria
+
+- [ ] Public API test exercises `Span<char>.RemoveAll` as a consumer would, asserting the documented contract (per `DECISIONS-DotExtensions-performance-improvements.md#D009`)
+- [ ] AOT runtime test exercises the public API under NativeAOT (per `DECISIONS-DotExtensions-performance-improvements.md#D010`)
+- [ ] Both tests pass (per `DECISIONS-DotExtensions-performance-improvements.md#D004`)
+
+## Dependencies
+
+**Blocked by** — 6. Requires the `Span<char>.RemoveAll` method from ticket 6.

--- a/tickets/perf/additive-span/008-additive-span-char-removeall-benchmark.md
+++ b/tickets/perf/additive-span/008-additive-span-char-removeall-benchmark.md
@@ -1,0 +1,66 @@
+---
+title: Additive Span - Span<char>.RemoveAll BDN benchmark
+classification: Independent
+blocked_by: [6]
+parent: docs/decisions/DECISIONS-DotExtensions-performance-improvements.md
+---
+
+## Goal
+
+Add a BDN benchmark for `Span<char>.RemoveAll` in `DotExtensions.Benchmarking` to establish the v10 baseline for this method.
+
+## What to build
+
+Add a BDN benchmark class in `DotExtensions.Benchmarking` that covers `Span<char>.RemoveAll` across short (16 chars), medium (256 chars), and long (4096 chars) inputs.
+
+## Recommended Workflow
+
+### Step 1 — Read the existing BDN benchmark project structure
+
+Where: `DotExtensions.Benchmarking/DotExtensions.Benchmarking.csproj`
+
+- Read existing benchmark classes to understand conventions
+- Note the BDN configuration and output format
+
+Verify: N/A
+
+### Step 2 — Create a new benchmark class for Span<char>.RemoveAll
+
+Where: `DotExtensions.Benchmarking/`
+
+- Create a benchmark class with 3 benchmark methods (short, medium, long)
+- Use ASCII-only inputs to avoid culture-specific flakiness
+- Configure BDN to measure allocation
+
+Verify: `dotnet build DotExtensions.Benchmarking -c Release` succeeds
+
+### Step 3 — Run the BDN benchmark and verify it produces the expected output
+
+Where: N/A
+
+- Run the benchmark using BDN
+- Confirm the benchmark runs without errors
+- Confirm the results are reasonable (no NaN or zero values)
+
+Verify: Benchmark output is valid
+
+## Context pointers
+
+**Files**
+- `DotExtensions.Benchmarking/DotExtensions.Benchmarking.csproj` — BDN benchmark project
+- `DotExtensions.Memory/DotExtensions.Memory.csproj` — Memory package project
+
+**Ledger records**
+- `DECISIONS-DotExtensions-performance-improvements.md#T007` — additive Span API surface
+- `DECISIONS-DotExtensions-performance-improvements.md#T010` — Span<char>.RemoveAll type design
+- `DECISIONS-DotExtensions-performance-improvements.md#D004` — v10 validation methodology
+- `DECISIONS-DotExtensions-performance-improvements.md#D007` — v10 sequencing
+
+## Acceptance criteria
+
+- [ ] BDN benchmark class covers `Span<char>.RemoveAll` across short (16), medium (256), and long (4096) inputs (per `DECISIONS-DotExtensions-performance-improvements.md#D004`)
+- [ ] Benchmark runs successfully and produces the expected output (per `DECISIONS-DotExtensions-performance-improvements.md#D007`)
+
+## Dependencies
+
+**Blocked by** — 6. Requires the `Span<char>.RemoveAll` method from ticket 6.

--- a/tickets/perf/existing-span/004-existing-span-optimization.md
+++ b/tickets/perf/existing-span/004-existing-span-optimization.md
@@ -1,0 +1,96 @@
+---
+title: Existing Span - SpanCopyExtensions optimization
+classification: Independent
+blocked_by: []
+parent: docs/decisions/DECISIONS-DotExtensions-performance-improvements.md
+---
+
+## Goal
+
+Optimize the existing Span code in `DotExtensions.Memory/Spans/` by consolidating the `ArgumentOutOfRangeException.ThrowIf*` calls into a shared private static helper and replacing `T[] outputArray = new T[length]` in `ReadOnlySpan<T>.OptimisticCopy` with `GC.AllocateUninitializedArray<T>(length)`.
+
+## What to build
+
+(a) Consolidate the `ArgumentOutOfRangeException.ThrowIf*` calls into a shared private static helper used by all `CopyTo`/`OptimisticCopy` overloads. (b) Replace `T[] outputArray = new T[length]` in `ReadOnlySpan<T>.OptimisticCopy` with `GC.AllocateUninitializedArray<T>(length)`. For `netstandard2.0`, verify the existing `Polyfill` package reference covers `GC.AllocateUninitializedArray` before relying on it; if not, use conditional compilation.
+
+## Recommended Workflow
+
+### Step 1 — Read SpanCopyExtensions.cs and identify all ArgumentOutOfRangeException.ThrowIf* calls
+
+Where: `DotExtensions.Memory/Spans/SpanCopyExtensions.cs`
+
+- Read the file to understand the current validation pattern
+- Identify all `ArgumentOutOfRangeException.ThrowIf*` calls
+
+Verify: N/A
+
+### Step 2 — Design a shared private static validation helper
+
+Where: `DotExtensions.Memory/Spans/SpanCopyExtensions.cs`
+
+- Design a helper that preserves the exact exception types and `paramName` values
+- Ensure the helper matches the current inline checks
+
+Verify: N/A
+
+### Step 3 — Refactor each callsite to use the shared helper
+
+Where: `DotExtensions.Memory/Spans/SpanCopyExtensions.cs`
+
+- Replace each inline `ArgumentOutOfRangeException.ThrowIf*` call with the shared helper
+- Verify the exception types and `paramName` values are preserved
+
+Verify: `dotnet build DotExtensions.Memory -c Release` succeeds
+
+### Step 4 — Verify the existing Polyfill package covers GC.AllocateUninitializedArray for netstandard2.0
+
+Where: `DotExtensions.Memory/DotExtensions.Memory.csproj`
+
+- Read the `Polyfill` NuGet package documentation
+- Verify coverage of `GC.AllocateUninitializedArray` for `netstandard2.0`
+
+Verify: Polyfill package covers the API, or conditional compilation is needed
+
+### Step 5 — Replace the allocation in ReadOnlySpan<T>.OptimisticCopy with GC.AllocateUninitializedArray<T>(length)
+
+Where: `DotExtensions.Memory/Spans/SpanCopyExtensions.cs`
+
+- Replace `T[] outputArray = new T[length]` with `GC.AllocateUninitializedArray<T>(length)`
+- Use conditional compilation if the Polyfill package does not cover the API
+
+Verify: `dotnet build DotExtensions.Memory -c Release` succeeds
+
+### Step 6 — Verify the existing AOT build passes
+
+Where: `DotExtensions.AotTests/DotExtensions.AotTests.csproj`
+
+- Run `dotnet build DotExtensions.AotTests -c Release`
+- Confirm no new AOT warnings are introduced
+
+Verify: AOT build succeeds with no new warnings
+
+## Context pointers
+
+**Files**
+- `DotExtensions.Memory/Spans/SpanCopyExtensions.cs` — source file to optimize
+- `DotExtensions.Memory/DotExtensions.Memory.csproj` — Memory package project
+
+**Ledger records**
+- `DECISIONS-DotExtensions-performance-improvements.md#T006` — existing Span optimization approach
+- `DECISIONS-DotExtensions-performance-improvements.md#D005` — v10 vs v11 scope allocation
+- `DECISIONS-DotExtensions-performance-improvements.md#D006` — bug standard for v10 behavior changes
+- `DECISIONS-DotExtensions-performance-improvements.md#D007` — v10 sequencing
+- `DECISIONS-DotExtensions-performance-improvements.md#D008` — v10 polyfill strategy
+
+## Acceptance criteria
+
+- [ ] All `ArgumentOutOfRangeException.ThrowIf*` calls are consolidated into a shared private static helper (per `DECISIONS-DotExtensions-performance-improvements.md#T006`)
+- [ ] The shared helper preserves the exact exception types and `paramName` values of the current inline checks (per `DECISIONS-DotExtensions-performance-improvements.md#D006`)
+- [ ] `ReadOnlySpan<T>.OptimisticCopy` uses `GC.AllocateUninitializedArray<T>(length)` instead of `new T[length]` (per `DECISIONS-DotExtensions-performance-improvements.md#T006`)
+- [ ] The `try/catch` safety net in `TryCopyTo` and the allocation in `Resize` are unchanged (per `DECISIONS-DotExtensions-performance-improvements.md#D006`)
+- [ ] The existing `Polyfill` package reference covers `GC.AllocateUninitializedArray` for `netstandard2.0`, or conditional compilation is used (per `DECISIONS-DotExtensions-performance-improvements.md#D008`)
+- [ ] Existing AOT build passes with no new warnings (per `DECISIONS-DotExtensions-performance-improvements.md#D010`)
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/perf/internal-refactor/009-internal-refactor-audit.md
+++ b/tickets/perf/internal-refactor/009-internal-refactor-audit.md
@@ -1,0 +1,76 @@
+---
+title: Internal-refactor - collection/array + boxing/conversion audit
+classification: Independent
+blocked_by: []
+parent: docs/decisions/DECISIONS-DotExtensions-performance-improvements.md
+---
+
+## Goal
+
+Audit the main `DotExtensions` package for collection/array allocation hotspots and boxing/conversion issues, producing a documented list of findings with per-finding PR scope for v10 internal-refactor work.
+
+## What to build
+
+Read the main `DotExtensions` package source files and identify: (a) collection/array allocation hotspots (e.g., unnecessary `ToList()`, `ToArray()`, `new List<T>()` where capacity is known, repeated allocations in loops), and (b) boxing/conversion issues (e.g., implicit boxing of value types, unnecessary `Convert` calls, `object` parameters where generics would avoid boxing). Document each finding with file path, line number, current behavior, proposed fix, and estimated impact. Each finding becomes a separate v10 PR per T008.
+
+## Recommended Workflow
+
+### Step 1 — Scan the main DotExtensions package for collection/array allocation hotspots
+
+Where: `DotExtensions/DotExtensions/System/`, `DotExtensions/DotExtensions/MsExtensions/`
+
+- Read source files across the main package
+- Identify collection/array allocation hotspots (unnecessary `ToList()`, `ToArray()`, `new List<T>()` without capacity, repeated allocations in loops)
+
+Verify: N/A
+
+### Step 2 — Scan the main DotExtensions package for boxing/conversion issues
+
+Where: `DotExtensions/DotExtensions/System/`, `DotExtensions/DotExtensions/MsExtensions/`
+
+- Read source files across the main package
+- Identify boxing/conversion issues (implicit boxing of value types, unnecessary `Convert` calls, `object` parameters where generics would avoid boxing)
+
+Verify: N/A
+
+### Step 3 — Document each finding with file path, line number, current behavior, proposed fix, and estimated impact
+
+Where: `docs/decisions/INTERNAL-REFACTOR-AUDIT-v10.md`
+
+- Create a markdown file documenting the audit results
+- For each finding, record: file path, line number, current behavior, proposed fix, estimated impact
+
+Verify: Audit document is created
+
+### Step 4 — Exclude LINQ/enumerator allocations and async/await internal optimizations from scope
+
+Where: N/A
+
+- Confirm LINQ/enumerator allocations and async/await internal optimizations are excluded from v10 scope (deferred to v11 per T008)
+- Note them as out-of-scope in the audit document
+
+Verify: N/A
+
+## Context pointers
+
+**Files**
+- `DotExtensions/DotExtensions/System/` — main package source files
+- `DotExtensions/DotExtensions/MsExtensions/` — main package source files
+
+**Ledger records**
+- `DECISIONS-DotExtensions-performance-improvements.md#T008` — v10 internal-refactor category scope
+- `DECISIONS-DotExtensions-performance-improvements.md#D005` — v10 vs v11 scope allocation
+- `DECISIONS-DotExtensions-performance-improvements.md#D006` — bug standard for v10 behavior changes
+- `DECISIONS-DotExtensions-performance-improvements.md#D007` — v10 sequencing
+
+## Acceptance criteria
+
+- [ ] Collection/array allocation hotspots are identified and documented (per `DECISIONS-DotExtensions-performance-improvements.md#T008`)
+- [ ] Boxing/conversion issues are identified and documented (per `DECISIONS-DotExtensions-performance-improvements.md#T008`)
+- [ ] Each finding includes file path, line number, current behavior, proposed fix, and estimated impact (per `DECISIONS-DotExtensions-performance-improvements.md#T008`)
+- [ ] LINQ/enumerator allocations and async/await internal optimizations are excluded from v10 scope (per `DECISIONS-DotExtensions-performance-improvements.md#T008`)
+- [ ] No public API surface is changed (per `DECISIONS-DotExtensions-performance-improvements.md#D005`)
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/perf/strings/001-strings-remove-extensions-refactor.md
+++ b/tickets/perf/strings/001-strings-remove-extensions-refactor.md
@@ -1,0 +1,93 @@
+---
+title: Strings - StringRemoveExtensions refactor (RemoveAll) + PR description skeleton
+classification: Independent
+blocked_by: []
+parent: docs/decisions/DECISIONS-DotExtensions-performance-improvements.md
+---
+
+## Goal
+
+Refactor `StringRemoveExtensions.RemoveAll` to use a single-pass `StringBuilder` scan, eliminating the repeated `string.Remove` allocations, and prepare the PR description skeleton (What/Why/How sections, without benchmark results table).
+
+## What to build
+
+Rewrite `RemoveAll` in `DotExtensions/System/Strings/Removal/StringRemoveExtensions.cs` to use a single-pass scan that appends non-matching runs to a `StringBuilder` and returns `sb.ToString()`. `RemoveFirst` and `RemoveLast` retain their current `string.Remove` allocation and are addressed in a future PR. The PR description includes "What changed", "Why", and "How" sections but does not yet include the BDN benchmark results table (that is added in ticket 2).
+
+## Recommended Workflow
+
+### Step 1 — Read the existing RemoveAll contract
+
+Where: `DotExtensions/System/Strings/Removal/StringRemoveExtensions.cs`
+
+- Read the XML doc comments for `RemoveAll` to understand the documented contract
+- Note the exception types and parameter validation
+
+Verify: N/A
+
+### Step 2 — Rewrite RemoveAll with single-pass StringBuilder scan
+
+Where: `DotExtensions/System/Strings/Removal/StringRemoveExtensions.cs`
+
+- Replace the `while` loop + `RemoveFirst` calls with a single-pass scan
+- Use a `StringBuilder` to append non-matching runs
+- Return `sb.ToString()`
+
+Verify: `dotnet build DotExtensions -c Release` succeeds
+
+### Step 3 — Add minimal invariant tests for RemoveAll
+
+Where: `DotExtensions.Tests/`
+
+- Add tests that assert the documented contract for `RemoveAll`
+- Cover null/empty throws, same return values, and basic removal scenarios
+
+Verify: `dotnet test DotExtensions.Tests` passes
+
+### Step 4 — Write PR description skeleton
+
+Where: PR description
+
+- Write "What changed", "Why", and "How" sections
+- Note that the benchmark results table is pending (ticket 2)
+
+Verify: N/A
+
+### Step 5 — Verify the existing AOT build passes
+
+Where: `DotExtensions.AotTests/DotExtensions.AotTests.csproj`
+
+- Run `dotnet build DotExtensions.AotTests -c Release`
+- Confirm no new AOT warnings are introduced
+
+Verify: AOT build succeeds with no new warnings
+
+## Context pointers
+
+**Files**
+- `DotExtensions/System/Strings/Removal/StringRemoveExtensions.cs` — source file to refactor
+- `DotExtensions.AotTests/DotExtensions.AotTests.csproj` — AOT build gate
+
+**Ledger records**
+- `DECISIONS-DotExtensions-performance-improvements.md#T001` — first v10 strings implementation (this file)
+- `DECISIONS-DotExtensions-performance-improvements.md#T002` — refactor approach (RemoveAll rewrite)
+- `DECISIONS-DotExtensions-performance-improvements.md#T005` — PR description approach
+- `DECISIONS-DotExtensions-performance-improvements.md#D001` — session goal (v10 perf wins)
+- `DECISIONS-DotExtensions-performance-improvements.md#D005` — v10 vs v11 scope allocation
+- `DECISIONS-DotExtensions-performance-improvements.md#D006` — bug standard for v10 behavior changes
+- `DECISIONS-DotExtensions-performance-improvements.md#D007` — v10 sequencing (strings first)
+- `DECISIONS-DotExtensions-performance-improvements.md#D009` — v10 test coverage expectations
+- `DECISIONS-DotExtensions-performance-improvements.md#D010` — v10 AOT compatibility expectations
+- `DECISIONS-DotExtensions-performance-improvements.md#D004` — v10 validation methodology
+
+## Acceptance criteria
+
+- [ ] `RemoveAll` uses a single-pass `StringBuilder` scan (per `DECISIONS-DotExtensions-performance-improvements.md#T002`)
+- [ ] `RemoveFirst` and `RemoveLast` are unchanged (per `DECISIONS-DotExtensions-performance-improvements.md#T002`)
+- [ ] Observable behavior is preserved: null/empty throws, same return values (per `DECISIONS-DotExtensions-performance-improvements.md#D006`)
+- [ ] Existing AOT build passes with no new warnings (per `DECISIONS-DotExtensions-performance-improvements.md#D010`)
+- [ ] Minimal invariant tests for `RemoveAll` pass (per `DECISIONS-DotExtensions-performance-improvements.md#D009`)
+- [ ] PR description includes "What changed", "Why", and "How" sections (per `DECISIONS-DotExtensions-performance-improvements.md#T005`)
+
+## Dependencies
+
+**Blocked by** — None. Can start immediately.

--- a/tickets/perf/strings/002-strings-remove-extensions-benchmark.md
+++ b/tickets/perf/strings/002-strings-remove-extensions-benchmark.md
@@ -1,0 +1,87 @@
+---
+title: Strings - StringRemoveExtensions BDN benchmark (3x3) + finalize PR description
+classification: Independent
+blocked_by: [1]
+parent: docs/decisions/DECISIONS-DotExtensions-performance-improvements.md
+---
+
+## Goal
+
+Add a BDN benchmark covering all three `StringRemoveExtensions` methods across short (16 chars), medium (256 chars), and long (4096 chars) inputs, producing a 3x3 matrix, and finalize the PR description with the benchmark results table.
+
+## What to build
+
+Add a BDN benchmark class in `DotExtensions.Benchmarking` that covers `RemoveAll`, `RemoveFirst`, and `RemoveLast` across short (16 chars), medium (256 chars), and long (4096 chars) inputs, producing a 3x3 matrix of benchmark methods. Run the benchmark and add the results table (method x size x mean x allocated) to the PR description from ticket 1.
+
+## Recommended Workflow
+
+### Step 1 — Read the existing BDN benchmark project structure
+
+Where: `DotExtensions.Benchmarking/DotExtensions.Benchmarking.csproj`
+
+- Read existing benchmark classes to understand conventions
+- Note the BDN configuration and output format
+
+Verify: N/A
+
+### Step 2 — Create a new benchmark class for StringRemoveExtensions
+
+Where: `DotExtensions.Benchmarking/`
+
+- Create a benchmark class with 9 benchmark methods (3 methods x 3 sizes)
+- Use ASCII-only inputs to avoid culture-specific flakiness
+- Configure BDN to measure allocation
+
+Verify: `dotnet build DotExtensions.Benchmarking -c Release` succeeds
+
+### Step 3 — Run the BDN benchmark and capture the results
+
+Where: N/A
+
+- Run the benchmark using BDN
+- Capture the results table (method x size x mean x allocated)
+
+Verify: Benchmark produces a 3x3 matrix of results
+
+### Step 4 — Update the PR description from ticket 1 with the benchmark results table
+
+Where: PR description
+
+- Add the benchmark results table (method x size x mean x allocated) to the PR description
+- Exclude BDN memory columns (analyzed in the BDN HTML report, not the PR)
+
+Verify: PR description includes the benchmark results table
+
+### Step 5 — Verify the benchmark runs successfully
+
+Where: N/A
+
+- Confirm the benchmark runs without errors
+- Confirm the results are reasonable (no NaN or zero values)
+
+Verify: Benchmark output is valid
+
+## Context pointers
+
+**Files**
+- `DotExtensions.Benchmarking/DotExtensions.Benchmarking.csproj` — BDN benchmark project
+- `DotExtensions/System/Strings/Removal/StringRemoveExtensions.cs` — source file being benchmarked
+
+**Ledger records**
+- `DECISIONS-DotExtensions-performance-improvements.md#T001` — first v10 strings implementation
+- `DECISIONS-DotExtensions-performance-improvements.md#T004` — BDN benchmark approach (3x3 matrix)
+- `DECISIONS-DotExtensions-performance-improvements.md#T005` — PR description approach
+- `DECISIONS-DotExtensions-performance-improvements.md#D004` — v10 validation methodology
+- `DECISIONS-DotExtensions-performance-improvements.md#D007` — v10 sequencing
+
+## Acceptance criteria
+
+- [ ] BDN benchmark class covers all three methods across short (16), medium (256), and long (4096) inputs (per `DECISIONS-DotExtensions-performance-improvements.md#T004`)
+- [ ] Benchmark produces a 3x3 matrix of results (per `DECISIONS-DotExtensions-performance-improvements.md#T004`)
+- [ ] PR description includes the benchmark results table (method x size x mean x allocated) (per `DECISIONS-DotExtensions-performance-improvements.md#T005`)
+- [ ] BDN memory columns are excluded from the PR table (per `DECISIONS-DotExtensions-performance-improvements.md#T005`)
+- [ ] Inputs are ASCII-only to avoid culture-specific flakiness (per `DECISIONS-DotExtensions-performance-improvements.md#T004`)
+
+## Dependencies
+
+**Blocked by** — 1. Requires the refactored `RemoveAll` from ticket 1.

--- a/tickets/perf/strings/003-strings-remove-extensions-invariant-tests.md
+++ b/tickets/perf/strings/003-strings-remove-extensions-invariant-tests.md
@@ -1,0 +1,91 @@
+---
+title: Strings - StringRemoveExtensions comprehensive invariant tests
+classification: Independent
+blocked_by: [1]
+parent: docs/decisions/DECISIONS-DotExtensions-performance-improvements.md
+---
+
+## Goal
+
+Add a comprehensive parameterized test suite for all three `StringRemoveExtensions` methods using TUnit `[Arguments]`, asserting the documented contract per XML doc comments and covering standard edge cases.
+
+## What to build
+
+Add a test class in `DotExtensions.Tests` that asserts the documented contract for `RemoveAll`, `RemoveFirst`, and `RemoveLast` per their XML doc comments, covers standard edge cases (null/empty inputs, value not found, value longer than input, value equals entire input, single occurrence, multiple occurrences), exercises each `StringComparison` value and asserts the result matches the comparison's semantics, and uses TUnit `[Arguments]` to parameterize inputs across short/medium/long strings, value positions, overlapping values, and Unicode.
+
+## Recommended Workflow
+
+### Step 1 — Read the XML doc comments for each method
+
+Where: `DotExtensions/System/Strings/Removal/StringRemoveExtensions.cs`
+
+- Read the XML doc comments for `RemoveAll`, `RemoveFirst`, and `RemoveLast`
+- Note the documented contract for each method
+
+Verify: N/A
+
+### Step 2 — Create a test class with parameterized tests using TUnit [Arguments]
+
+Where: `DotExtensions.Tests/`
+
+- Create a test class for `StringRemoveExtensions`
+- Use TUnit `[Arguments]` to parameterize inputs
+
+Verify: `dotnet build DotExtensions.Tests -c Release` succeeds
+
+### Step 3 — Add tests for standard edge cases
+
+Where: `DotExtensions.Tests/`
+
+- Add tests for null/empty inputs
+- Add tests for value not found
+- Add tests for value longer than input
+- Add tests for value equals entire input
+- Add tests for single occurrence
+- Add tests for multiple occurrences
+
+Verify: `dotnet test DotExtensions.Tests` passes
+
+### Step 4 — Add tests for each StringComparison value
+
+Where: `DotExtensions.Tests/`
+
+- Add tests for each `StringComparison` value
+- Assert the result matches the comparison's semantics
+
+Verify: `dotnet test DotExtensions.Tests` passes
+
+### Step 5 — Verify all tests pass
+
+Where: N/A
+
+- Run the full test suite
+- Confirm all tests pass
+
+Verify: `dotnet test DotExtensions.Tests` passes
+
+## Context pointers
+
+**Files**
+- `DotExtensions.Tests/DotExtensions.Tests.csproj` — test project
+- `DotExtensions/System/Strings/Removal/StringRemoveExtensions.cs` — source file being tested
+
+**Ledger records**
+- `DECISIONS-DotExtensions-performance-improvements.md#T001` — first v10 strings implementation
+- `DECISIONS-DotExtensions-performance-improvements.md#T003` — test approach (parameterized tests)
+- `DECISIONS-DotExtensions-performance-improvements.md#D006` — bug standard for v10 behavior changes
+- `DECISIONS-DotExtensions-performance-improvements.md#D009` — v10 test coverage expectations
+- `DECISIONS-DotExtensions-performance-improvements.md#D004` — v10 validation methodology
+
+## Acceptance criteria
+
+- [ ] Tests assert the documented contract per XML doc comments (per `DECISIONS-DotExtensions-performance-improvements.md#D006`)
+- [ ] Standard edge cases are covered: null/empty inputs, value not found, value longer than input, value equals entire input, single occurrence, multiple occurrences (per `DECISIONS-DotExtensions-performance-improvements.md#T003`)
+- [ ] Each `StringComparison` value is exercised and the result matches the comparison's semantics (per `DECISIONS-DotExtensions-performance-improvements.md#T003`)
+- [ ] TUnit `[Arguments]` is used to parameterize inputs across short/medium/long strings, value positions, overlapping values, and Unicode (per `DECISIONS-DotExtensions-performance-improvements.md#T003`)
+- [ ] Test inputs are pinned to ASCII or stable Unicode to avoid flakiness (per `DECISIONS-DotExtensions-performance-improvements.md#T003`)
+- [ ] Allocation count assertions are excluded (the BDN benchmark covers allocation regression per `DECISIONS-DotExtensions-performance-improvements.md#D004`)
+
+## Dependencies
+
+**Blocked by** — 1. Requires the refactored `RemoveAll` from ticket 1 to verify tests pass against the new implementation.


### PR DESCRIPTION
## Summary

Performance-focused refactor targeting two hot paths in v10

## Changes

- **`StringRemoveExtensions.RemoveAll`** — replaced repeated `RemoveFirst` loop (O(n²) allocations) with a single-pass `StringBuilder` scan
- **`SpanCopyExtensions`** — extracted duplicated bounds-validation into a shared `ValidateCopyRange` helper; switched fallback allocation to `GC.AllocateUninitializedArray<T>`
- Added unit tests for `RemoveAll` (invariant culture, missing value, full removal, etc.)
- Added design/audit documentation for future v10 performance work

## Checklist

- [x] `dotnet build -c Release` passes
- [x] `dotnet test` passes
- [x] New tests cover the refactored `RemoveAll` paths