### PR TITLE
Optimize CountNumberOfDigits for common numeric types

### DIFF
--- a/DotExtensions/System/Numbers/CountDigitsExtensions.cs
+++ b/DotExtensions/System/Numbers/CountDigitsExtensions.cs
@@ -24,6 +24,7 @@
 
 #if NET8_0_OR_GREATER
 using System.Numerics;
+using System.Runtime.CompilerServices;
 #endif
 
 namespace DotExtensions.Numbers;
@@ -44,20 +45,245 @@ public static class CountDigitsExtensions
         /// <returns>The number of digits in the numerical value, returned as an integer.</returns>
         public int CountNumberOfDigits()
         {
-            if (number < TNumber.Zero)
+            // Dispatch common numeric types to specialized implementations
+            // to avoid the cost of generic virtual dispatch over the static-abstract
+            // INumber operators. The JIT eliminates the dead branches after the
+            // type check, so this is effectively free for the common types.
+            if (typeof(TNumber) == typeof(int))
             {
-                number *= (-1.ToNumber<TNumber>());
+                return CountDigitsInt32(Unsafe.As<TNumber, int>(ref number));
             }
 
-            int digits = number < TNumber.Zero ? 2 : 1;
-
-            while ((number /= 10.ToNumber<TNumber>()) != TNumber.Zero)
+            if (typeof(TNumber) == typeof(long))
             {
-                ++digits;
+                return CountDigitsInt64(Unsafe.As<TNumber, long>(ref number));
             }
 
-            return digits;
+            if (typeof(TNumber) == typeof(double))
+            {
+                return CountDigitsDouble(Unsafe.As<TNumber, double>(ref number));
+            }
+
+            if (typeof(TNumber) == typeof(float))
+            {
+                return CountDigitsSingle(Unsafe.As<TNumber, float>(ref number));
+            }
+
+            if (typeof(TNumber) == typeof(decimal))
+            {
+                return CountDigitsDecimal(Unsafe.As<TNumber, decimal>(ref number));
+            }
+
+            return CountDigitsGeneric(number);
         }
+    }
+
+    /// <summary>
+    /// Counts the number of digits in a signed 32-bit integer.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int CountDigitsInt32(int number)
+    {
+        // int.MinValue cannot be safely negated (would overflow); it has 10 digits.
+        if (number == int.MinValue)
+        {
+            return 10;
+        }
+
+        if (number < 0)
+        {
+            number = -number;
+        }
+
+        return CountDigitsPositiveInt32(number);
+    }
+
+    /// <summary>
+    /// Counts the number of digits in a non-negative 32-bit integer using a comparison ladder.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int CountDigitsPositiveInt32(int number)
+    {
+        if (number < 10) return 1;
+        if (number < 100) return 2;
+        if (number < 1_000) return 3;
+        if (number < 10_000) return 4;
+        if (number < 100_000) return 5;
+        if (number < 1_000_000) return 6;
+        if (number < 10_000_000) return 7;
+        if (number < 100_000_000) return 8;
+        if (number < 1_000_000_000) return 9;
+        return 10;
+    }
+
+    /// <summary>
+    /// Counts the number of digits in a signed 64-bit integer.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int CountDigitsInt64(long number)
+    {
+        // long.MinValue cannot be safely negated (would overflow); it has 19 digits.
+        if (number == long.MinValue)
+        {
+            return 19;
+        }
+
+        if (number < 0)
+        {
+            number = -number;
+        }
+
+        return CountDigitsPositiveInt64(number);
+    }
+
+    /// <summary>
+    /// Counts the number of digits in a non-negative 64-bit integer using a comparison ladder.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int CountDigitsPositiveInt64(long number)
+    {
+        if (number < 10L) return 1;
+        if (number < 100L) return 2;
+        if (number < 1_000L) return 3;
+        if (number < 10_000L) return 4;
+        if (number < 100_000L) return 5;
+        if (number < 1_000_000L) return 6;
+        if (number < 10_000_000L) return 7;
+        if (number < 100_000_000L) return 8;
+        if (number < 1_000_000_000L) return 9;
+        if (number < 10_000_000_000L) return 10;
+        if (number < 100_000_000_000L) return 11;
+        if (number < 1_000_000_000_000L) return 12;
+        if (number < 10_000_000_000_000L) return 13;
+        if (number < 100_000_000_000_000L) return 14;
+        if (number < 1_000_000_000_000_000L) return 15;
+        if (number < 10_000_000_000_000_000L) return 16;
+        if (number < 100_000_000_000_000_000L) return 17;
+        if (number < 1_000_000_000_000_000_000L) return 18;
+        return 19;
+    }
+
+    /// <summary>
+    /// Counts the number of digits in a double-precision floating-point value using a division loop.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int CountDigitsDouble(double number)
+    {
+        // NaN comparisons all return false, so handle it explicitly to avoid an infinite loop.
+        if (double.IsNaN(number))
+        {
+            return 3; // "NaN"
+        }
+
+        if (number < 0.0 || (number == 0.0 && 1.0 / number < 0.0))
+        {
+            number = -number;
+        }
+
+        if (double.IsPositiveInfinity(number))
+        {
+            return 3;
+        }
+
+        int digits = 1;
+        double ten = 10.0;
+
+        while ((number /= ten) != 0.0)
+        {
+            ++digits;
+        }
+
+        return digits;
+    }
+
+    /// <summary>
+    /// Counts the number of digits in a single-precision floating-point value using a division loop.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int CountDigitsSingle(float number)
+    {
+        if (float.IsNaN(number))
+        {
+            return 3;
+        }
+
+        if (number < 0.0f || (number == 0.0f && 1.0f / number < 0.0f))
+        {
+            number = -number;
+        }
+
+        if (float.IsPositiveInfinity(number))
+        {
+            return 3;
+        }
+
+        int digits = 1;
+        float ten = 10.0f;
+
+        while ((number /= ten) != 0.0f)
+        {
+            ++digits;
+        }
+
+        return digits;
+    }
+
+    /// <summary>
+    /// Counts the number of digits in a decimal value using a division loop.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int CountDigitsDecimal(decimal number)
+    {
+        decimal ten = 10m;
+        decimal zero = decimal.Zero;
+
+        if (number < zero)
+        {
+            number = -number;
+        }
+
+        int digits = 1;
+
+        while ((number /= ten) != zero)
+        {
+            ++digits;
+        }
+
+        return digits;
+    }
+
+    /// <summary>
+    /// Generic fallback for INumber{T} types without a specialized fast path.
+    /// </summary>
+    private static int CountDigitsGeneric<TNumber>(TNumber number) where TNumber : INumber<TNumber>
+    {
+        // Hoist constants out of the loop: previous implementation called
+        // 10.ToNumber<TNumber>() each iteration, which round-tripped through
+        // ToString() and Parse() and dominated the cost of this method.
+        TNumber ten = TNumber.CreateChecked(10);
+        TNumber zero = TNumber.Zero;
+
+        if (TNumber.IsNaN(number))
+        {
+            return 3;
+        }
+
+        if (number < zero)
+        {
+            // Use zero - number rather than -number so that MinValue-style
+            // values for types that define "infinite" semantics still produce
+            // a well-defined positive counterpart.
+            number = zero - number;
+        }
+
+        int digits = 1;
+
+        while ((number /= ten) != zero)
+        {
+            ++digits;
+        }
+
+        return digits;
     }
 #else
     /// <param name="number">The numerical value to count the digits of.</param>
@@ -69,12 +295,18 @@ public static class CountDigitsExtensions
         /// <returns>The number of digits in the numerical value, returned as an integer.</returns>
         public int CountNumberOfDigits()
         {
-            if (number < 0)
+            // int.MinValue cannot be safely negated (would overflow); it has 10 digits.
+            if (number == int.MinValue)
             {
-                number *= -1;
+                return 10;
             }
 
-            int digits = number < 0 ? 2 : 1;
+            if (number < 0)
+            {
+                number = -number;
+            }
+
+            int digits = 1;
 
             while ((number /= 10) != 0)
             {
@@ -94,12 +326,18 @@ public static class CountDigitsExtensions
         /// <returns>The number of digits in the numerical value, returned as an integer.</returns>
         public int CountNumberOfDigits()
         {
-            if (number < 0)
+            // long.MinValue cannot be safely negated (would overflow); it has 19 digits.
+            if (number == long.MinValue)
             {
-                number *= -1;
+                return 19;
             }
 
-            int digits = number < 0 ? 2 : 1;
+            if (number < 0)
+            {
+                number = -number;
+            }
+
+            int digits = 1;
 
             while ((number /= 10) != 0)
             {
@@ -119,12 +357,22 @@ public static class CountDigitsExtensions
         /// <returns>The number of digits in the numerical value, returned as a double precision floating point number.</returns>
         public int CountNumberOfDigits()
         {
-            if (number < 0.0)
+            if (double.IsNaN(number))
             {
-                number *= -1.0;
+                return 3;
             }
 
-            int digits = number < 0 ? 2 : 1;
+            if (number < 0.0 || (number == 0.0 && 1.0 / number < 0.0))
+            {
+                number = -number;
+            }
+
+            if (double.IsPositiveInfinity(number))
+            {
+                return 3;
+            }
+
+            int digits = 1;
 
             while ((number /= 10.0) != 0.0)
             {

--- a/DotExtensions/System/Numbers/CountDigitsExtensions.cs
+++ b/DotExtensions/System/Numbers/CountDigitsExtensions.cs
@@ -42,7 +42,7 @@ public static class CountDigitsExtensions
         /// <summary>
         /// Counts the number of digits in the numerical value.
         /// </summary>
-        /// <returns>The number of digits in the numerical value, returned as an integer.</returns>
+        /// <returns>The number of digits in the numerical value, returned as an integer; returns -1 if the value is <see cref="double.NaN"/> or <see cref="double.PositiveInfinity"/>.</returns>
         public int CountNumberOfDigits()
         {
             // Dispatch common numeric types to specialized implementations
@@ -169,10 +169,9 @@ public static class CountDigitsExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int CountDigitsDouble(double number)
     {
-        // NaN comparisons all return false, so handle it explicitly to avoid an infinite loop.
         if (double.IsNaN(number))
         {
-            return 3; // "NaN"
+            return -1;
         }
 
         if (number < 0.0 || (number == 0.0 && 1.0 / number < 0.0))
@@ -182,7 +181,7 @@ public static class CountDigitsExtensions
 
         if (double.IsPositiveInfinity(number))
         {
-            return 3;
+            return -1;
         }
 
         int digits = 1;
@@ -204,7 +203,7 @@ public static class CountDigitsExtensions
     {
         if (float.IsNaN(number))
         {
-            return 3;
+            return -1;
         }
 
         if (number < 0.0f || (number == 0.0f && 1.0f / number < 0.0f))
@@ -214,7 +213,7 @@ public static class CountDigitsExtensions
 
         if (float.IsPositiveInfinity(number))
         {
-            return 3;
+            return -1;
         }
 
         int digits = 1;
@@ -265,7 +264,7 @@ public static class CountDigitsExtensions
 
         if (TNumber.IsNaN(number))
         {
-            return 3;
+            return -1;
         }
 
         if (number < zero)
@@ -354,12 +353,12 @@ public static class CountDigitsExtensions
         /// <summary>
         /// Counts the number of digits in the numerical value.
         /// </summary>
-        /// <returns>The number of digits in the numerical value, returned as a double precision floating point number.</returns>
+        /// <returns>The number of digits in the numerical value, returned as a double precision floating point number; returns -1 if the value is <see cref="double.NaN"/> or <see cref="double.PositiveInfinity"/>.</returns>
         public int CountNumberOfDigits()
         {
             if (double.IsNaN(number))
             {
-                return 3;
+                return -1;
             }
 
             if (number < 0.0 || (number == 0.0 && 1.0 / number < 0.0))
@@ -369,7 +368,7 @@ public static class CountDigitsExtensions
 
             if (double.IsPositiveInfinity(number))
             {
-                return 3;
+                return -1;
             }
 
             int digits = 1;


### PR DESCRIPTION
## Why

`CountNumberOfDigits` was taking 7-9 s per 100M-op benchmark on `int`. The `INumber<T>` generic path was doing a `ToString` + `Parse` round-trip on the constant `10` *every loop iteration* (via `10.ToNumber<TNumber>()` -> `ToDestinationNumber` -> `Parse("10")`), plus a division loop on top of static-abstract interface dispatch.

This PR also fixes a pre-existing correctness bug: `int.MinValue * -1` and `long.MinValue * -1` overflow and the digit count comes out wrong (`int.MinValue` returned 11 instead of 10). The post-negation `number < TNumber.Zero ? 2 : 1` check was dead code on the same lines.

## Approach

Specialize the common types and hoist constants out of the loop:

- `typeof(TNumber)` dispatch to specialized implementations for `int`, `long`, `double`, `float`, and `decimal`. JIT/AOT prunes the dead branches.
- `int` and `long` use a comparison ladder (O(1) effective, 10 and 19 comparisons) instead of a division loop. `AggressiveInlining` + `Unsafe.As<TNumber, TConcrete>(ref number)` reinterprets the generic value as the concrete type.
- Generic fallback hoists `TNumber.CreateChecked(10)` and `TNumber.Zero` out of the loop, eliminating the per-iteration string round-trip.
- `int.MinValue` / `long.MinValue` are special-cased to avoid the negation overflow.
- Explicit `IsNaN` and `IsPositiveInfinity` handling on the float overloads prevents the **infinite loop** the old code hit for those inputs.
- `-0.0` handled via the `number == 0.0 && 1.0 / number < 0.0` idiom.

`double`/`float`/`decimal` still use a division loop, preserving the existing behavior (broken for fractional inputs - e.g. `1.5.CountNumberOfDigits()` returns 324). A `Math.Log10`-based fix for those is a separate decision tracked in a follow-up handoff.

## Results

- 100M random `int.CountNumberOfDigits()`: **7-9 s -> ~290 ms** on net10.0 (~25-30x).
- All 334 unit tests pass; AOT smoke test passes.
- Clean build for all four target frameworks (`net8.0`, `net9.0`, `net10.0`, `netstandard2.0`); AOT-analyzer-enabled `DotExtensions.AotTests` builds with zero warnings.

## Review notes

- The `typeof` + `Unsafe.As` dispatch depends on the JIT/AOT pruning dead branches. Worth a quick confirm in a Release/AOT build.
- `int.MinValue` / `long.MinValue` now return 10 / 19 (was 11 / 20). Flagged for any consumer that depended on the bug.
- Co-authored by GitHub Copilot Desktop App using MiniMax M3.