### PR TITLE
Add StringRemoveExtensions benchmark, invariant tests, and Span<char>.RemoveAll

### DIFF
--- a/DotExtensions.AotTests/Program.cs
+++ b/DotExtensions.AotTests/Program.cs
@@ -33,4 +33,11 @@ span[5] = 6;
 span[6] = 7;
 Console.WriteLine($"Span last two => {span[5]}, {span[6]}");
 
+// Memory/Spans: char removal
+char[] chars = "hello world, world!".ToCharArray();
+Span<char> charSpan = chars;
+int newLength = charSpan.RemoveAll("world");
+Console.WriteLine($"charSpan new length => {newLength}");
+Console.WriteLine($"charSpan contents => {charSpan[..newLength].ToString()}");
+
 Console.WriteLine(Resources.DotExtensions_AoT_Messages_Outro);

--- a/DotExtensions.Benchmarking/Benchmarks/Strings/StringRemoveExtensionsBenchmarks.cs
+++ b/DotExtensions.Benchmarking/Benchmarks/Strings/StringRemoveExtensionsBenchmarks.cs
@@ -1,0 +1,84 @@
+/*
+        MIT License
+
+       Copyright (c) 2026 Alastair Lundy
+
+       Permission is hereby granted, free of charge, to any person obtaining a copy
+       of this software and associated documentation files (the "Software"), to deal
+       in the Software without restriction, including without limitation the rights
+       to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+       copies of the Software, and to permit persons to whom the Software is
+       furnished to do so, subject to the following conditions:
+
+       The above copyright notice and this permission notice shall be included in all
+       copies or substantial portions of the Software.
+
+       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+       IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+       FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+       AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+       LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+       OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+       SOFTWARE.
+   */
+
+using System;
+using System.Linq;
+using DotExtensions.Strings;
+
+namespace DotExtensions.Benchmarking.Benchmarks.Strings;
+
+/// <summary>
+/// Benchmark for <see cref="StringRemoveExtensions"/> methods across three input sizes
+/// (short 16, medium 256, long 4096 chars), producing a 3x3 matrix of
+/// (method x size) results.
+/// </summary>
+/// <remarks>
+/// Inputs are ASCII-only to avoid culture-specific flakiness. The same generated
+/// source string is used for every method at a given <see cref="N"/> so that the
+/// only thing varying between the three methods is the algorithm itself.
+/// </remarks>
+[ShortRunJob(RuntimeMoniker.Net80)]
+[ShortRunJob(RuntimeMoniker.Net90)]
+[ShortRunJob(RuntimeMoniker.Net10_0)]
+[MemoryDiagnoser]
+[CsvMeasurementsExporter]
+public class StringRemoveExtensionsBenchmarks
+{
+    private const string Needle = "ab";
+
+    private string _source = string.Empty;
+
+    /// <summary>Source string length. Cycle is "abcd" (4 chars) so <see cref="N"/> must be a multiple of 4.</summary>
+    [Params(16, 256, 4096)]
+    public int N;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        const int cycleLength = 4;
+        int repeats = N / cycleLength;
+        _source = string.Concat(Enumerable.Repeat("abcd", repeats));
+    }
+
+    [Benchmark]
+    public string RemoveAll_ShortMediumLong()
+    {
+        // "abcdabcd..." -> "cdcdcd..." (N/2 chars)
+        return _source.RemoveAll(Needle, StringComparison.Ordinal);
+    }
+
+    [Benchmark]
+    public string RemoveFirst_ShortMediumLong()
+    {
+        // "abcdabcd..." -> "cdabcdabcd..." (N-2 chars)
+        return _source.RemoveFirst(Needle, StringComparison.Ordinal);
+    }
+
+    [Benchmark]
+    public string RemoveLast_ShortMediumLong()
+    {
+        // "abcdabcd..." -> "abcdabcd...cd" (N-2 chars)
+        return _source.RemoveLast(Needle, StringComparison.Ordinal);
+    }
+}

--- a/DotExtensions.Memory/Spans/SpanCharRemoveExtensions.cs
+++ b/DotExtensions.Memory/Spans/SpanCharRemoveExtensions.cs
@@ -1,0 +1,160 @@
+/*
+        MIT License
+
+       Copyright (c) 2026 Alastair Lundy
+
+       Permission is hereby granted, free of charge, to any person obtaining a copy
+       of this software and associated documentation files (the "Software"), to deal
+       in the Software without restriction, including without limitation the rights
+       to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+       copies of the Software, and to permit persons to whom the Software is
+       furnished to do so, subject to the following conditions:
+
+       The above copyright notice and this permission notice shall be included in all
+       copies or substantial portions of the Software.
+
+       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+       IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+       FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+       AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+       LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+       OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+       SOFTWARE.
+   */
+
+namespace DotExtensions.Memory.Spans;
+
+/// <summary>
+/// Provides extension methods for removing substrings from <see cref="Span{T}"/> of characters
+/// in place, mirroring the documented contract of <c>DotExtensions.Strings.StringRemoveExtensions</c>.
+/// </summary>
+public static class SpanCharRemoveExtensions
+{
+    /// <param name="source">The <see cref="Span{T}"/> of characters to update in place.</param>
+    extension(ref Span<char> source)
+    {
+        /// <summary>
+        /// Removes all occurrences of <paramref name="value"/> from <paramref name="source"/> in place,
+        /// using the specified <see cref="StringComparison"/> rules, and returns the new length
+        /// of the span after removal.
+        /// </summary>
+        /// <param name="value">The substring to remove. Must not be empty.</param>
+        /// <param name="stringComparison">The rules to use when comparing substrings.</param>
+        /// <returns>
+        /// The new length of <paramref name="source"/> after all occurrences of
+        /// <paramref name="value"/> have been removed. Callers typically slice the span with
+        /// <c>source = source[..newLength];</c> to trim trailing characters.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="value"/> is empty.
+        /// </exception>
+        public int RemoveAll(
+            ReadOnlySpan<char> value,
+            StringComparison stringComparison = StringComparison.CurrentCulture)
+        {
+            if (value.IsEmpty)
+                throw new ArgumentException(
+                    "The substring to remove must not be empty.",
+                    nameof(value));
+
+            int sourceLength = source.Length;
+            int valueLength = value.Length;
+
+            if (valueLength > sourceLength)
+                return sourceLength;
+
+            if (stringComparison == StringComparison.Ordinal)
+                return RemoveAllOrdinal(ref source, value, sourceLength, valueLength);
+
+            return RemoveAllWithComparison(ref source, value, stringComparison, sourceLength, valueLength);
+        }
+    }
+
+    private static int RemoveAllOrdinal(
+        ref Span<char> source,
+        ReadOnlySpan<char> value,
+        int sourceLength,
+        int valueLength)
+    {
+        int searchStart = 0;
+        int writePos = 0;
+
+        while (searchStart <= sourceLength - valueLength)
+        {
+            int relative = source.Slice(searchStart).IndexOf(value);
+
+            if (relative == -1)
+            {
+                AppendTail(ref source, sourceLength, searchStart, ref writePos);
+                return writePos;
+            }
+
+            int index = searchStart + relative;
+
+            if (index > searchStart)
+            {
+                source.Slice(searchStart, index - searchStart)
+                    .CopyTo(source.Slice(writePos));
+                writePos += index - searchStart;
+            }
+
+            searchStart = index + valueLength;
+        }
+
+        AppendTail(ref source, sourceLength, searchStart, ref writePos);
+        return writePos;
+    }
+
+    private static int RemoveAllWithComparison(
+        ref Span<char> source,
+        ReadOnlySpan<char> value,
+        StringComparison stringComparison,
+        int sourceLength,
+        int valueLength)
+    {
+        // For culture-aware comparisons, hoist a single string copy of the source
+        // and value outside the loop so each iteration does not allocate.
+        string sourceString = source.ToString();
+        string valueString = value.ToString();
+
+        int searchStart = 0;
+        int writePos = 0;
+
+        while (searchStart <= sourceLength - valueLength)
+        {
+            int index = sourceString.IndexOf(valueString, searchStart, stringComparison);
+
+            if (index == -1)
+            {
+                AppendTail(ref source, sourceLength, searchStart, ref writePos);
+                return writePos;
+            }
+
+            if (index > searchStart)
+            {
+                source.Slice(searchStart, index - searchStart)
+                    .CopyTo(source.Slice(writePos));
+                writePos += index - searchStart;
+            }
+
+            searchStart = index + valueLength;
+        }
+
+        AppendTail(ref source, sourceLength, searchStart, ref writePos);
+        return writePos;
+    }
+
+    private static void AppendTail(
+        ref Span<char> source,
+        int sourceLength,
+        int searchStart,
+        ref int writePos)
+    {
+        if (searchStart >= sourceLength)
+            return;
+
+        int remaining = sourceLength - searchStart;
+        source.Slice(searchStart, remaining).CopyTo(source.Slice(writePos));
+        writePos += remaining;
+    }
+}

--- a/DotExtensions.Tests/Strings/StringRemoveExtensionsTests.cs
+++ b/DotExtensions.Tests/Strings/StringRemoveExtensionsTests.cs
@@ -1,0 +1,404 @@
+/*
+        MIT License
+
+       Copyright (c) 2026 Alastair Lundy
+
+       Permission is hereby granted, free of charge, to any person obtaining a copy
+       of this software and associated documentation files (the "Software"), to deal
+       in the Software without restriction, including without limitation the rights
+       to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+       copies of the Software, and to permit persons to whom the Software is
+       furnished to do so, subject to the following conditions:
+
+       The above copyright notice and this permission notice shall be included in all
+       copies or substantial portions of the Software.
+
+       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+       IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+       FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+       AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+       LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+       OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+       SOFTWARE.
+   */
+
+using System;
+using System.Linq;
+using DotExtensions.Strings;
+
+namespace DotExtensions.Tests.Strings;
+
+/// <summary>
+/// Comprehensive invariant tests for <see cref="StringRemoveExtensions"/>.
+/// These tests assert the documented contract per XML doc comments (D006) using
+/// TUnit <c>[Arguments]</c> parameterization (T003) with ASCII or stable
+/// Unicode inputs to avoid culture-sensitive flakiness.
+/// </summary>
+public class StringRemoveExtensionsTests
+{
+    // -----------------------------------------------------------------------
+    // RemoveAll: edge cases
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [Arguments(null, "x")]
+    [Arguments("", "x")]
+    [Arguments("hello", null)]
+    [Arguments("hello", "")]
+    public async Task RemoveAll_InvalidInputs_ThrowArgumentException(string? source, string? value)
+    {
+        await Assert.That(() => source!.RemoveAll(value!, StringComparison.Ordinal))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    [Arguments("abc", "abcdef")]
+    [Arguments("ab", "abc")]
+    [Arguments("a", "aa")]
+    public async Task RemoveAll_ValueLongerThanSource_ReturnsOriginalUnchanged(string source, string value)
+    {
+        string result = source.RemoveAll(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(source);
+    }
+
+    [Test]
+    [Arguments("hello world", "xyz")]
+    [Arguments("foo bar baz", "qux")]
+    [Arguments("aaaaa", "bbbb")]
+    public async Task RemoveAll_ValueNotPresent_ReturnsOriginalUnchanged(string source, string value)
+    {
+        string result = source.RemoveAll(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(source);
+    }
+
+    [Test]
+    [Arguments("aaaaa", "a", "")]
+    [Arguments("abcabc", "abc", "")]
+    [Arguments("xyzxyzxyz", "xyz", "")]
+    public async Task RemoveAll_OnlyOccurrences_ReturnsEmptyString(string source, string value, string expected)
+    {
+        string result = source.RemoveAll(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("abc", "abc", "")]
+    [Arguments("hello", "hello", "")]
+    [Arguments("xxxxx", "xxxxx", "")]
+    public async Task RemoveAll_ValueEqualsEntireSource_ReturnsEmptyString(string source, string value, string expected)
+    {
+        string result = source.RemoveAll(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    // -----------------------------------------------------------------------
+    // RemoveAll: parameterized output tests (short/medium/long, single/multi,
+    // leading/trailing/middle occurrences)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [Arguments("hello world", "world", "hello ")]
+    [Arguments("hello world", "hello", " world")]
+    [Arguments("hello world", "o", "hell wrld")]
+    [Arguments("hello world", "l", "heo word")]
+    [Arguments("aXbXcXd", "X", "abcd")]
+    [Arguments("abcXYZdef", "XYZ", "abcdef")]
+    [Arguments("fooXXbarXXbaz", "XX", "foobarbaz")]
+    [Arguments("ababab", "ab", "")]
+    [Arguments("Mississippi", "ss", "Miiippi")]
+    [Arguments("aabbcc", "b", "aacc")]
+    public async Task RemoveAll_Ordinal_ReturnsExpected(string source, string value, string expected)
+    {
+        string result = source.RemoveAll(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("Hello World", "hello", StringComparison.OrdinalIgnoreCase, " World")]
+    [Arguments("ABCABC", "abc", StringComparison.OrdinalIgnoreCase, "")]
+    [Arguments("FooBar", "FOO", StringComparison.OrdinalIgnoreCase, "Bar")]
+    [Arguments("FOOFOOFOO", "foo", StringComparison.OrdinalIgnoreCase, "")]
+    public async Task RemoveAll_CaseInsensitive_RemovesAllOccurrences(
+        string source, string value, StringComparison comparison, string expected)
+    {
+        string result = source.RemoveAll(value, comparison);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("Hello World", "hello", StringComparison.Ordinal, "Hello World")]
+    [Arguments("ABCABC", "abc", StringComparison.Ordinal, "ABCABC")]
+    [Arguments("FooBar", "FOO", StringComparison.Ordinal, "FooBar")]
+    public async Task RemoveAll_CaseSensitive_DoesNotRemoveDifferentCase(
+        string source, string value, StringComparison comparison, string expected)
+    {
+        string result = source.RemoveAll(value, comparison);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("hello world", "world", StringComparison.CurrentCulture, "hello ")]
+    [Arguments("Hello World", "hello", StringComparison.CurrentCultureIgnoreCase, " World")]
+    [Arguments("hello world", "world", StringComparison.InvariantCulture, "hello ")]
+    [Arguments("Hello World", "hello", StringComparison.InvariantCultureIgnoreCase, " World")]
+    public async Task RemoveAll_AllCultureComparisons_BehaveConsistentlyWithOrdinal(
+        string source, string value, StringComparison comparison, string expected)
+    {
+        // For ASCII inputs culture-aware comparisons must produce the same result
+        // as ordinal comparisons. This guards against regressions where
+        // culture-specific behaviour is unintentionally introduced.
+        string result = source.RemoveAll(value, comparison);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("aabaabaab", "aab", "")]
+    [Arguments("abcabcabc", "abcabc", "abc")]
+    [Arguments("aaaaa", "aa", "a")]
+    [Arguments("xxxxxx", "xxx", "")]
+    public async Task RemoveAll_OverlappingValues_StillRemovesAllNonOverlappingOccurrences(
+        string source, string value, string expected)
+    {
+        // "RemoveAll" is defined to find non-overlapping occurrences from left to
+        // right. This test pins that semantic so it cannot silently change.
+        string result = source.RemoveAll(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("héllo wörld", "héllo", " wörld")]
+    [Arguments("élève élève élève", "élève", "  ")]
+    [Arguments("naïve naïve", "naïve", " ")]
+    public async Task RemoveAll_StableUnicode_RemovesAllOccurrences(string source, string value, string expected)
+    {
+        // Stable Unicode (NFC normalised) inputs to keep comparisons deterministic
+        // regardless of the host culture or default ICU data.
+        string result = source.RemoveAll(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task RemoveAll_LongString_RepeatedOccurrences()
+    {
+        string value = "abc";
+        string source = string.Concat(Enumerable.Repeat("abc", 1_000));
+        string expected = string.Empty;
+
+        string result = source.RemoveAll(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task RemoveAll_LongString_NoOccurrences()
+    {
+        string value = "xyz";
+        string source = string.Concat(Enumerable.Repeat("abc", 1_000));
+
+        string result = source.RemoveAll(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(source);
+    }
+
+    [Test]
+    public async Task RemoveAll_LongString_SingleOccurrence()
+    {
+        string value = "needle";
+        string source = string.Concat(Enumerable.Repeat("haystack ", 1_000)) + value;
+
+        string result = source.RemoveAll(value, StringComparison.Ordinal);
+
+        string expected = string.Concat(Enumerable.Repeat("haystack ", 1_000));
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    // -----------------------------------------------------------------------
+    // RemoveFirst: edge cases
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [Arguments(null, "x")]
+    [Arguments("", "x")]
+    [Arguments("hello", null)]
+    [Arguments("hello", "")]
+    public async Task RemoveFirst_InvalidInputs_ThrowArgumentException(string? source, string? value)
+    {
+        await Assert.That(() => source!.RemoveFirst(value!, StringComparison.Ordinal))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    [Arguments("abc", "abcdef")]
+    [Arguments("ab", "abc")]
+    public async Task RemoveFirst_ValueLongerThanSource_ThrowsArgumentException(string source, string value)
+    {
+        await Assert.That(() => source.RemoveFirst(value, StringComparison.Ordinal))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    [Arguments("hello world", "xyz")]
+    [Arguments("foo bar", "qux")]
+    public async Task RemoveFirst_ValueNotPresent_ThrowsArgumentException(string source, string value)
+    {
+        await Assert.That(() => source.RemoveFirst(value, StringComparison.Ordinal))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    [Arguments("hello world", "world", "hello ")]
+    [Arguments("hello world", "hello", " world")]
+    [Arguments("hello world", "o", "hell world")]
+    [Arguments("abcabc", "abc", "abc")]
+    [Arguments("Mississippi", "ss", "Miissippi")]
+    [Arguments("foo bar foo", "foo", " bar foo")]
+    public async Task RemoveFirst_Ordinal_RemovesOnlyFirstOccurrence(
+        string source, string value, string expected)
+    {
+        string result = source.RemoveFirst(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("Hello World", "hello", StringComparison.OrdinalIgnoreCase, " World")]
+    [Arguments("FOObar", "foo", StringComparison.OrdinalIgnoreCase, "bar")]
+    [Arguments("FOOFOO", "foo", StringComparison.OrdinalIgnoreCase, "FOO")]
+    public async Task RemoveFirst_CaseInsensitive_RemovesFirstOccurrence(
+        string source, string value, StringComparison comparison, string expected)
+    {
+        string result = source.RemoveFirst(value, comparison);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task RemoveFirst_CaseSensitive_DoesNotMatchDifferentCase()
+    {
+        const string source = "Hello World";
+        const string value = "hello";
+
+        await Assert.That(() => source.RemoveFirst(value, StringComparison.Ordinal))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    [Arguments("abc", "abc", "")]
+    [Arguments("hello", "hello", "")]
+    public async Task RemoveFirst_ValueEqualsEntireSource_ReturnsEmptyString(
+        string source, string value, string expected)
+    {
+        string result = source.RemoveFirst(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    // -----------------------------------------------------------------------
+    // RemoveLast: edge cases
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [Arguments(null, "x")]
+    [Arguments("", "x")]
+    [Arguments("hello", null)]
+    [Arguments("hello", "")]
+    public async Task RemoveLast_InvalidInputs_ThrowArgumentException(string? source, string? value)
+    {
+        await Assert.That(() => source!.RemoveLast(value!, StringComparison.Ordinal))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    [Arguments("abc", "abcdef")]
+    [Arguments("ab", "abc")]
+    public async Task RemoveLast_ValueLongerThanSource_ThrowsArgumentException(string source, string value)
+    {
+        await Assert.That(() => source.RemoveLast(value, StringComparison.Ordinal))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    [Arguments("hello world", "xyz")]
+    [Arguments("foo bar", "qux")]
+    public async Task RemoveLast_ValueNotPresent_ThrowsArgumentException(string source, string value)
+    {
+        await Assert.That(() => source.RemoveLast(value, StringComparison.Ordinal))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    [Arguments("hello world", "world", "hello ")]
+    [Arguments("hello world", "hello", " world")]
+    [Arguments("hello world", "o", "hello wrld")]
+    [Arguments("abcabc", "abc", "abc")]
+    [Arguments("Mississippi", "ss", "Missiippi")]
+    [Arguments("foo bar foo", "foo", "foo bar ")]
+    public async Task RemoveLast_Ordinal_RemovesOnlyLastOccurrence(
+        string source, string value, string expected)
+    {
+        string result = source.RemoveLast(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("Hello World", "hello", StringComparison.OrdinalIgnoreCase, " World")]
+    [Arguments("FOObar", "foo", StringComparison.OrdinalIgnoreCase, "bar")]
+    [Arguments("FOOFOO", "foo", StringComparison.OrdinalIgnoreCase, "FOO")]
+    public async Task RemoveLast_CaseInsensitive_RemovesLastOccurrence(
+        string source, string value, StringComparison comparison, string expected)
+    {
+        string result = source.RemoveLast(value, comparison);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task RemoveLast_CaseSensitive_DoesNotMatchDifferentCase()
+    {
+        const string source = "Hello World";
+        const string value = "hello";
+
+        await Assert.That(() => source.RemoveLast(value, StringComparison.Ordinal))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    [Arguments("abc", "abc", "")]
+    [Arguments("hello", "hello", "")]
+    public async Task RemoveLast_ValueEqualsEntireSource_ReturnsEmptyString(
+        string source, string value, string expected)
+    {
+        string result = source.RemoveLast(value, StringComparison.Ordinal);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-method: removing the same value should produce a consistent
+    // result when only one occurrence exists, regardless of which method
+    // is used. This guards against subtle contract drift between methods.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [Arguments("hello world", "world")]
+    [Arguments("foo bar baz", "bar")]
+    [Arguments("abcabcabc", "abc")]
+    public async Task RemoveFirstAndRemoveLast_Agree_WhenOnlyOneOccurrence(string source, string value)
+    {
+        string first = source.RemoveFirst(value, StringComparison.Ordinal);
+        string last = source.RemoveLast(value, StringComparison.Ordinal);
+
+        await Assert.That(first).IsEqualTo(last);
+    }
+}


### PR DESCRIPTION
## Why

The V10 perf improvements part 1 PR refactored `StringRemoveExtensions` and optimized `SpanCopyExtensions`, but left three follow-up gaps: no `Span<char>` equivalent of `RemoveAll`, no invariant coverage of the new `RemoveFirst` / `RemoveLast`, and no BDN baseline for any of the three. This PR closes those gaps.

## What changed

### `Span<char>.RemoveAll`

- `DotExtensions.Memory/Spans/SpanCharRemoveExtensions.cs`: C# 14 `extension(ref Span<char> source)` block exposing `int RemoveAll(ReadOnlySpan<char> value, StringComparison = CurrentCulture)`.
- Mirrors `StringRemoveExtensions.RemoveAll`: throws `ArgumentException` on empty `value`, returns `sourceLength` when `value` is longer than source, and uses an allocation-free `Span.Slice().IndexOf(value)` for the ordinal path. Non-ordinal runs hoist `source.ToString()` and `value.ToString()` out of the loop.
- Implementation is split into `RemoveAllOrdinal`, `RemoveAllWithComparison`, and `AppendTail` so each method stays under the analyzer's MA0051 length limit.
- AOT runtime exercise added to `DotExtensions.AotTests/Program.cs`.

### Invariant tests

- `DotExtensions.Tests/Strings/StringRemoveExtensionsTests.cs`: 90 TUnit tests parameterized over `RemoveAll`, `RemoveFirst`, `RemoveLast`, every `StringComparison` value, and the edge cases documented in the XML doc comments (null/empty inputs, value not present, value longer than source, value equal to source, single and multiple occurrences, overlapping values, stable Unicode, large strings). Includes a cross-method consistency test.
- 424/424 tests pass (90 new + 334 existing).

### BDN matrix

- `DotExtensions.Benchmarking/Benchmarks/Strings/StringRemoveExtensionsBenchmarks.cs`: 3 (methods) x 3 (sizes) x 3 (runtimes) matrix using `[ShortRunJob]`. Methods: `RemoveAll`, `RemoveFirst`, `RemoveLast`. Sizes: 16, 256, 4096 chars. Runtimes: net8.0, net9.0, net10.0. `[MemoryDiagnoser]` and `[CsvMeasurementsExporter]` enabled.

## Benchmark results (ShortRun, 1 launch x 3 iterations)

| N   | Method      | net8.0   | net9.0   | net10.0  | Allocated |
|-----|-------------|----------|----------|----------|-----------|
| 16  | RemoveAll   | 51.7 ns  | 52.8 ns  | 38.6 ns  | 144 B     |
| 16  | RemoveFirst | 14.6 ns  | 14.0 ns  | 10.0 ns  | 56 B      |
| 16  | RemoveLast  | 16.4 ns  | 15.6 ns  | 11.1 ns  | 56 B      |
| 256 | RemoveAll   | 666 ns   | 672 ns   | 632 ns   | 864 B     |
| 256 | RemoveFirst | 31.4 ns  | 33.5 ns  | 32.3 ns  | 536 B     |
| 256 | RemoveLast  | 38.2 ns  | 36.4 ns  | 29.6 ns  | 536 B     |
| 4096| RemoveAll   | 11.0 us  | 11.1 us  | 9.87 us  | 12384 B   |
| 4096| RemoveFirst | 256 ns   | 308 ns   | 237 ns   | 8216 B    |
| 4096| RemoveLast  | 301 ns   | 298 ns   | 243 ns   | 8216 B    |

`RemoveAll` is the slowest of the three, as expected (full string walk plus in-place compaction), and scales linearly with N. Performance is consistent across runtimes, with .NET 10 having a slight edge at the largest size.

## Notes

- The polyfill package does not cover `string.IndexOf(ReadOnlySpan<char>, int, StringComparison)`, so the non-ordinal path materializes `value` as a string. `source` is also materialized for non-ordinal runs, but only once per call. This matches `StringRemoveExtensions.RemoveAll` and keeps `netstandard2.0` support.
- `[ShortRunJob]` keeps the full 27-benchmark run under 4 minutes. Swap in `[SimpleJob]` or `[MediumRunJob]` if tighter confidence is needed before a release.
- `Program.cs` still uses `BenchmarkRunner.Run(Assembly.GetCallingAssembly())`, so the new class runs alongside the existing benchmarks.
- Three pre-existing MA0074 warnings in `LineEndingExtensions.cs` are not caused by this change.

## Verification

- `dotnet build` of all four projects: 0 errors, 0 new warnings.
- `dotnet test`: 424/424 pass.
- BDN run: 27 benchmarks completed in 3:32, CSV exported.

> Co-authored by GitHub Copilot App using MiniMax M3