### PR TITLE
Remove .NET Standard 2.0, .NET 8, and .NET 9 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,18 +130,18 @@ dotnet run -c Release --filter *ClassName*MethodName*
 
 Multiple glob patterns can follow `--filter`. The filter is applied on top of `--quick` if both are specified.
 
-### Multi-TFM benchmarks
+### TFM
 
-The project multi-targets `net8.0;net9.0;net10.0`. Default runs use the TFM of the executing SDK. To validate all three:
+The project targets `net10.0`. Default runs use the TFM of the executing SDK. To run with a specific TFM:
 
 ```sh
 dotnet run -c Release --tfm all
 ```
 
-This re-spawns the process for each TFM. To run a single TFM explicitly:
+This re-spawns the process for each configured TFM. To run a single TFM explicitly:
 
 ```sh
-dotnet run -c Release -f net8.0
+dotnet run -c Release -f net10.0
 ```
 
 ### Default TFM and overriding it
@@ -149,7 +149,7 @@ dotnet run -c Release -f net8.0
 The default TFM is determined by the SDK (`dotnet run` picks the latest compatible). Override with `-f <tfm>`:
 
 ```sh
-dotnet run -c Release -f net9.0
+dotnet run -c Release -f net10.0
 ```
 
 For a complete reference, see `DotExtensions.Benchmarking/README.md`.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,11 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.10" />
     <PackageVersion Include="Meziantou.Analyzer" Version="3.0.125" />
     <PackageVersion Include="Polyfill" Version="11.0.1" />
-    <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-    <PackageVersion Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Bogus" Version="35.6.5" />

--- a/DotExtensions.AotTests/DotExtensions.AotTests.csproj
+++ b/DotExtensions.AotTests/DotExtensions.AotTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/DotExtensions.Benchmarking/DotExtensions.Benchmarking.csproj
+++ b/DotExtensions.Benchmarking/DotExtensions.Benchmarking.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/DotExtensions.Benchmarking/Program.cs
+++ b/DotExtensions.Benchmarking/Program.cs
@@ -22,7 +22,7 @@ string[] filterPatterns = ParseArgs(args, out bool quick, out bool tfmAll);
 
 if (tfmAll)
 {
-    string[] tfms = ["net8.0", "net9.0", "net10.0"];
+    string[] tfms = ["net10.0"];
 
     // Forward all args except --tfm all so child processes don't loop.
     string[] childArgs = args

--- a/DotExtensions.Benchmarking/README.md
+++ b/DotExtensions.Benchmarking/README.md
@@ -49,12 +49,12 @@ dotnet run -c Release --quick --filter *DigitCounting*
 dotnet run -c Release --tfm all
 ```
 
-Runs the suite for `net8.0`, `net9.0`, and `net10.0` sequentially by re-spawning the process for each TFM. Individual TFM runs still accept `--quick` and `--filter`.
+Runs the suite for `net10.0` sequentially by re-spawning the process for each TFM. Individual TFM runs still accept `--quick` and `--filter`.
 
 To target a single TFM without `--tfm all`:
 
 ```sh
-dotnet run -c Release -f net8.0
+dotnet run -c Release -f net10.0
 ```
 
 ## Benchmark classes and input sizes

--- a/DotExtensions.Memory/DotExtensions.Memory.csproj
+++ b/DotExtensions.Memory/DotExtensions.Memory.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net8.0;net9.0;netstandard2.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -31,16 +31,14 @@
     <FileVersion>10.5.0</FileVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework) != 'netstandard2.0' OR $(TargetFramework) == 'netstandard2.1'">
+  <PropertyGroup>
     <IsAoTCompatible>true</IsAoTCompatible>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
   </PropertyGroup>
 
-
   <ItemGroup>
     <PackageReference Include="Meziantou.Analyzer" PrivateAssets="all"/>
     <PackageReference Include="Polyfill" PrivateAssets="all"/>
-    <PackageReference Include="System.Memory" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/DotExtensions.Memory/README.md
+++ b/DotExtensions.Memory/README.md
@@ -31,9 +31,6 @@ DotExtensions.Memory can be installed via the .NET SDK CLI, Nuget via your IDE o
 
 ### Compatibility
 DotExtensions.Memory supports:
-* .NET Standard 2.0
-* .NET 8
-* .NET 9
 * .NET 10
 
 However, it is important to note that not all features may be supported by all TFMs.

--- a/DotExtensions.Tests/Dates/DateOnlySubtractionExtensionsTests.cs
+++ b/DotExtensions.Tests/Dates/DateOnlySubtractionExtensionsTests.cs
@@ -22,7 +22,6 @@
        SOFTWARE.
    */
 
-#if NET8_0_OR_GREATER
 using System;
 using DotExtensions.Dates;
 
@@ -194,4 +193,3 @@ public class DateOnlySubtractionExtensionsTests
         await Assert.That(result).IsEqualTo(new DateOnly(2024, 2, 28));
     }
 }
-#endif

--- a/DotExtensions.Tests/Dates/DateOnlyToDateTimeExtensionsTests.cs
+++ b/DotExtensions.Tests/Dates/DateOnlyToDateTimeExtensionsTests.cs
@@ -22,7 +22,6 @@
        SOFTWARE.
    */
 
-#if NET8_0_OR_GREATER
 using System;
 using DotExtensions.Dates;
 
@@ -72,4 +71,3 @@ public class DateOnlyToDateTimeExtensionsTests
         await Assert.That(result.Day).IsEqualTo(31);
     }
 }
-#endif

--- a/DotExtensions.Tests/Dates/TimeSpanDifferenceExtensionsTests.cs
+++ b/DotExtensions.Tests/Dates/TimeSpanDifferenceExtensionsTests.cs
@@ -85,7 +85,6 @@ public class TimeSpanDifferenceExtensionsTests
         await Assert.That(result).IsEqualTo(expected);
     }
 
-#if NET8_0_OR_GREATER
     [Test]
     [Arguments(10, 30, 0, 8, 15, 0)]
     [Arguments(23, 59, 59, 0, 0, 0)]
@@ -166,5 +165,4 @@ public class TimeSpanDifferenceExtensionsTests
 
         await Assert.That(result).IsEqualTo(TimeSpan.Zero);
     }
-#endif
 }

--- a/DotExtensions/DotExtensions.csproj
+++ b/DotExtensions/DotExtensions.csproj
@@ -4,7 +4,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <TargetFrameworks>net10.0;net8.0;net9.0;netstandard2.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <Title>DotExtensions</Title>
     <Authors>Alastair Lundy</Authors>
     <Copyright>Copyright (c) Alastair Lundy 2020-2026</Copyright>
@@ -38,15 +38,10 @@
       <FileVersion>10.5.0</FileVersion>
   </PropertyGroup>
 
-    <PropertyGroup Condition="$(TargetFramework) != 'netstandard2.0' OR $(TargetFramework) == 'netstandard2.1'">
+    <PropertyGroup>
         <IsAoTCompatible>true</IsAoTCompatible>
         <EnableAotAnalyzer>true</EnableAotAnalyzer>
     </PropertyGroup>
-    
-    <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
-        <PackageReference Include="Microsoft.Bcl.Memory"  />
-        <PackageReference Include="System.IO.FileSystem.AccessControl"/>
-    </ItemGroup>
     
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Primitives" />

--- a/DotExtensions/MsExtensions/Primitives/Cases/SegmentCapitalizationExtensions.cs
+++ b/DotExtensions/MsExtensions/Primitives/Cases/SegmentCapitalizationExtensions.cs
@@ -75,9 +75,7 @@ public static class SegmentCapitalizationExtensions
                 if (index == -1)
                     throw new ArgumentException(
                         Resources.Exceptions_Indices_IndexOutOfRange.Replace("{0}", index.ToString("N", CultureInfo.CurrentCulture)
-#if NET8_0_OR_GREATER
                             , StringComparison.Ordinal
-#endif
                         ), nameof(indices));
                     
                 if(index >= segment.Length)

--- a/DotExtensions/System/Dates/DateOnlyExtensions/DateOnlySubtractionExtensions.cs
+++ b/DotExtensions/System/Dates/DateOnlyExtensions/DateOnlySubtractionExtensions.cs
@@ -22,7 +22,6 @@
        SOFTWARE.
    */
 
-#if NET8_0_OR_GREATER
 namespace DotExtensions.Dates;
 
 /// <summary>
@@ -67,4 +66,3 @@ public static class DateOnlySubtractionExtensions
         }
     }
 }
-#endif

--- a/DotExtensions/System/Dates/DateOnlyExtensions/DateOnlyToDateTimeExtension.cs
+++ b/DotExtensions/System/Dates/DateOnlyExtensions/DateOnlyToDateTimeExtension.cs
@@ -22,7 +22,6 @@
        SOFTWARE.
    */
 
-#if NET8_0_OR_GREATER
 namespace DotExtensions.Dates;
 
 /// <summary>
@@ -44,4 +43,3 @@ public static class DateOnlyToDateTimeExtension
             DateTime.Parse(dateOnly.ToLongDateString(), CultureInfo.CurrentCulture, DateTimeStyles.None);
     }
 }
-#endif

--- a/DotExtensions/System/Dates/DateTimeSubtractExtensions.cs
+++ b/DotExtensions/System/Dates/DateTimeSubtractExtensions.cs
@@ -109,7 +109,6 @@ public static class DateTimeSubtractExtensions
         public DateTime SubtractYears(double years) =>
             dateTime.AddYears(-(int)years);
 
-#if NET8_0_OR_GREATER
         /// <summary>
         /// Subtract a specified number of microseconds from a DateTime.
         /// </summary>
@@ -118,6 +117,5 @@ public static class DateTimeSubtractExtensions
         [Obsolete(DeprecationMessages.DeprecationV11)]
         public DateTime SubtractMicroseconds(double microseconds) =>
             dateTime.Subtract(TimeSpan.FromMicroseconds(microseconds));
-#endif
     }
 }

--- a/DotExtensions/System/Dates/DayInExtensions.cs
+++ b/DotExtensions/System/Dates/DayInExtensions.cs
@@ -41,7 +41,6 @@ public static class DayInExtensions
         return days;
     }
 
-#if NET8_0_OR_GREATER
     /// <summary>
     /// Extensions to calculate the number of days in a <see cref="DateOnly"/> object within a time interval.
     /// </summary>
@@ -55,7 +54,6 @@ public static class DayInExtensions
         public int CalculateNumberOfDaysInYear()
             => CalculateDaysInYear(dateOnly.Year);
     }
-#endif
     
     /// <param name="date">The <see cref="DateTime"/> object representing the year to calculate the total number of days for.</param>
     extension(DateTime date)

--- a/DotExtensions/System/Dates/DayOfExtensions.cs
+++ b/DotExtensions/System/Dates/DayOfExtensions.cs
@@ -64,7 +64,6 @@ public static class DayOfExtensions
         return output;
     }
     
-#if NET8_0_OR_GREATER
     extension(DateOnly date)
     {
         /// <summary>
@@ -74,7 +73,6 @@ public static class DayOfExtensions
         public int CalculateDayOfWeekAsInteger()
             => CalculateDayOfWeekInt(date.DayOfWeek);
     }
-#endif
     
     /// <summary>
     ///

--- a/DotExtensions/System/Dates/TimeSpanDifferenceExtensions.cs
+++ b/DotExtensions/System/Dates/TimeSpanDifferenceExtensions.cs
@@ -45,7 +45,6 @@ public static class TimeSpanDifferenceExtensions
         }
     }
 
-#if NET8_0_OR_GREATER
     /// <param name="timeOnlyOne">The first time to be subtracted.</param>
     extension(TimeOnly timeOnlyOne)
     {
@@ -73,5 +72,4 @@ public static class TimeSpanDifferenceExtensions
         public TimeSpan Difference(DateOnly dateOnlyTwo) => DateOnly.ToDateTime(dateOnlyOne).Date
             .Difference(DateOnly.ToDateTime(dateOnlyTwo).Date);
     }
-#endif
 }

--- a/DotExtensions/System/Dates/WeekOfExtensions.cs
+++ b/DotExtensions/System/Dates/WeekOfExtensions.cs
@@ -108,7 +108,6 @@ public static class WeekOfExtensions
             InternalWeekOfYearCount(date, calendarWeekRule, date.Year);
     }
 
-#if NET8_0_OR_GREATER
     /// <param name="date"></param>
     extension(DateOnly date)
     {
@@ -127,5 +126,4 @@ public static class WeekOfExtensions
         public int WeekOfYear(CalendarWeekRule calendarWeekRule = CalendarWeekRule.FirstFullWeek) =>
             InternalWeekOfYearCount(DateOnly.ToDateTime(date), calendarWeekRule, date.Year);
     }
-#endif
 }

--- a/DotExtensions/System/IO/Directories/GetDirectoryExtensions.cs
+++ b/DotExtensions/System/IO/Directories/GetDirectoryExtensions.cs
@@ -60,14 +60,9 @@ public static class GetDirectoryExtensions
             }
 
             if (!fileInfo.Exists)
-#if NET8_0_OR_GREATER
                 throw new ArgumentException(
                     Resources.Exceptions_Directory_FileArgumentNotFound.Replace("{0}", fileInfo.Name, 
                         StringComparison.OrdinalIgnoreCase), nameof(fileInfo));
-#else
-                throw new ArgumentException(
-                    Resources.Exceptions_Directory_FileArgumentNotFound.Replace("{0}", fileInfo.Name), nameof(fileInfo));
-#endif
 
             DirectoryInfo? directory = DriveInfo.SafelyEnumerateLogicalDrives()
                 .Select(d => d.RootDirectory)

--- a/DotExtensions/System/IO/Directories/IsDirectoryEmptyExtensions.cs
+++ b/DotExtensions/System/IO/Directories/IsDirectoryEmptyExtensions.cs
@@ -31,6 +31,16 @@ namespace DotExtensions.IO.Directories;
 /// </summary>
 public static class IsDirectoryEmptyExtensions
 {
+    private static void ThrowIfDirectoryNotFound(DirectoryInfo directory)
+    {
+        ArgumentNullException.ThrowIfNull(directory);
+
+        if (!directory.Exists)
+            throw new DirectoryNotFoundException(
+                Resources.Exceptions_IO_DirectoryNotFound.Replace("{x}", directory.FullName,
+                    StringComparison.OrdinalIgnoreCase));
+    }
+
     /// <summary>
     /// Provides extension methods for checking if a directory is empty.
     /// </summary>
@@ -45,12 +55,7 @@ public static class IsDirectoryEmptyExtensions
         {
             get
             {
-                ArgumentNullException.ThrowIfNull(directory);
-
-                if (!directory.Exists)
-                    throw new DirectoryNotFoundException(
-                        Resources.Exceptions_IO_DirectoryNotFound.Replace("{x}", directory.FullName,
-                            StringComparison.OrdinalIgnoreCase));
+                ThrowIfDirectoryNotFound(directory);
 
                 return !directory.SafelyEnumerateFiles().Any() &&
                        !directory.SafelyEnumerateDirectories().Any();
@@ -66,12 +71,7 @@ public static class IsDirectoryEmptyExtensions
         {
             get
             {
-                ArgumentNullException.ThrowIfNull(directory);
-
-                if (!directory.Exists)
-                    throw new DirectoryNotFoundException(
-                        Resources.Exceptions_IO_DirectoryNotFound.Replace("{x}", directory.FullName,
-                            StringComparison.OrdinalIgnoreCase));
+                ThrowIfDirectoryNotFound(directory);
 
                 return directory.SafelyEnumerateFiles().Any();
             }

--- a/DotExtensions/System/IO/Directories/IsDirectoryEmptyExtensions.cs
+++ b/DotExtensions/System/IO/Directories/IsDirectoryEmptyExtensions.cs
@@ -48,14 +48,9 @@ public static class IsDirectoryEmptyExtensions
                 ArgumentNullException.ThrowIfNull(directory);
 
                 if (!directory.Exists)
-#if NET8_0_OR_GREATER
                     throw new DirectoryNotFoundException(
                         Resources.Exceptions_IO_DirectoryNotFound.Replace("{x}", directory.FullName,
                             StringComparison.OrdinalIgnoreCase));
-#else
-                    throw new DirectoryNotFoundException(
-                        Resources.Exceptions_IO_DirectoryNotFound.Replace("{x}", directory.FullName));
-#endif
 
                 return !directory.SafelyEnumerateFiles().Any() &&
                        !directory.SafelyEnumerateDirectories().Any();
@@ -74,14 +69,9 @@ public static class IsDirectoryEmptyExtensions
                 ArgumentNullException.ThrowIfNull(directory);
 
                 if (!directory.Exists)
-#if NET8_0_OR_GREATER
                     throw new DirectoryNotFoundException(
                         Resources.Exceptions_IO_DirectoryNotFound.Replace("{x}", directory.FullName,
                             StringComparison.OrdinalIgnoreCase));
-#else
-                    throw new DirectoryNotFoundException(
-                        Resources.Exceptions_IO_DirectoryNotFound.Replace("{x}", directory.FullName));
-#endif
 
                 return directory.SafelyEnumerateFiles().Any();
             }

--- a/DotExtensions/System/IO/GetRandomIOExtensions.cs
+++ b/DotExtensions/System/IO/GetRandomIOExtensions.cs
@@ -145,12 +145,8 @@ public static class GetRandomIOExtensions
                 : Environment.SystemDirectory;
             
             return new DirectoryInfo(sysDir).Parent ?? 
-#if NET8_0_OR_GREATER
                    throw new DirectoryNotFoundException(Resources.Exceptions_IO_DirectoryNotFound.Replace("{x}",
                        sysDir, StringComparison.OrdinalIgnoreCase));
-#else
-                   throw new DirectoryNotFoundException(Resources.Exceptions_IO_DirectoryNotFound.Replace("{x}", sysDir));
-#endif
         }
 
         /// <summary>

--- a/DotExtensions/System/IO/Permissions/PermissionExtensions.Unix.cs
+++ b/DotExtensions/System/IO/Permissions/PermissionExtensions.Unix.cs
@@ -37,11 +37,7 @@ public static partial class PermissionExtensions
         /// Whether the specified Unix file mode has execute permission.
         /// </summary>
         [Obsolete(DeprecationMessages.DeprecationV11)]
-#if NET8_0_OR_GREATER
         public
-#else
-        internal
-#endif
             bool HasExecutePermission
         {
             get
@@ -56,11 +52,7 @@ public static partial class PermissionExtensions
         /// Whether the specified Unix file mode has read permission.
         /// </summary>
         [Obsolete(DeprecationMessages.DeprecationV11)]
-#if NET8_0_OR_GREATER
         public
-#else
-        internal
-#endif
             bool HasReadPermission
         {
             get
@@ -75,11 +67,7 @@ public static partial class PermissionExtensions
         /// Whether the specified Unix file mode has write permission.
         /// </summary>
         [Obsolete(DeprecationMessages.DeprecationV11)]
-#if NET8_0_OR_GREATER
         public
-#else
-        internal
-#endif
             bool HasWritePermission
         {
             get

--- a/DotExtensions/System/IO/Permissions/Unix/UnixPermissionParsingExtensions.cs
+++ b/DotExtensions/System/IO/Permissions/Unix/UnixPermissionParsingExtensions.cs
@@ -22,7 +22,6 @@
        SOFTWARE.
    */
 
-#if NET8_0_OR_GREATER
 namespace DotExtensions.IO.Permissions.Unix;
 
 /// <summary>
@@ -215,4 +214,3 @@ public static class UnixPermissionParsingExtensions
     }
     #endregion
 }
-#endif

--- a/DotExtensions/System/IO/Permissions/Windows/WindowsFileAccessRulesExtensions.cs
+++ b/DotExtensions/System/IO/Permissions/Windows/WindowsFileAccessRulesExtensions.cs
@@ -81,11 +81,7 @@ public static class WindowsFileAccessRulesExtensions
             PlatformNotSupportedException.ThrowIfNotOSPlatform(OSPlatform.Windows);
             
             if(!file.Exists)
-#if NET8_0_OR_GREATER
                 throw new FileNotFoundException(Resources.Exceptions_FileNotFound.Replace("{file}", file.FullName, StringComparison.OrdinalIgnoreCase));
-#else
-                throw new FileNotFoundException(Resources.Exceptions_FileNotFound.Replace("{file}", file.FullName));
-#endif
             
             FileSecurity fileSecurity = file.GetAccessControl(AccessControlSections.Access);
             
@@ -138,13 +134,8 @@ public static class WindowsFileAccessRulesExtensions
             PlatformNotSupportedException.ThrowIfNotOSPlatform(OSPlatform.Windows);
             
             if(!directory.Exists)
-#if NET8_0_OR_GREATER
                 throw new DirectoryNotFoundException(Resources.Exceptions_DirectoryNotFound.Replace("{directory}",
                     directory.Name, StringComparison.OrdinalIgnoreCase));
-#else
-                throw new DirectoryNotFoundException(Resources.Exceptions_DirectoryNotFound.Replace("{directory}",
-                    directory.Name));
-#endif
         
             DirectorySecurity directorySecurity = directory.GetAccessControl(AccessControlSections.Access);
             AuthorizationRuleCollection results = directorySecurity.GetAccessRules(includeExplicit: true,

--- a/DotExtensions/System/IO/SafeEnumerationExtensions.cs
+++ b/DotExtensions/System/IO/SafeEnumerationExtensions.cs
@@ -37,11 +37,7 @@ public static class SafeEnumerationExtensions
         /// </summary>
         /// <param name="matchCasing">Specifies whether file and directory names should be matched case-sensitively.</param>
         /// <returns>Returns an <see cref="EnumerationOptions"/> object configured for safe and conditional file enumeration.</returns>
-#if NET8_0_OR_GREATER
         public
-#else
-        internal
-#endif
             EnumerationOptions ToEnumerationOptions(bool matchCasing = false)
         {
             return new EnumerationOptions

--- a/DotExtensions/System/Numbers/CountDigitsExtensions.cs
+++ b/DotExtensions/System/Numbers/CountDigitsExtensions.cs
@@ -22,10 +22,8 @@
        SOFTWARE.
    */
 
-#if NET8_0_OR_GREATER
 using System.Numerics;
 using System.Runtime.CompilerServices;
-#endif
 
 namespace DotExtensions.Numbers;
 
@@ -34,7 +32,6 @@ namespace DotExtensions.Numbers;
 /// </summary>
 public static class CountDigitsExtensions
 {
-#if NET8_0_OR_GREATER
     /// <param name="number">The numerical value to count the digits of.</param>
     /// <typeparam name="TNumber">The type inheriting from <see cref="INumber{TSelf}"/></typeparam>
     extension<TNumber>(TNumber number) where TNumber : INumber<TNumber>
@@ -284,102 +281,4 @@ public static class CountDigitsExtensions
 
         return digits;
     }
-#else
-    /// <param name="number">The numerical value to count the digits of.</param>
-    extension(int number)
-    {
-        /// <summary>
-        /// Counts the number of digits in the integer value.
-        /// </summary>
-        /// <returns>The number of digits in the numerical value, returned as an integer.</returns>
-        public int CountNumberOfDigits()
-        {
-            // int.MinValue cannot be safely negated (would overflow); it has 10 digits.
-            if (number == int.MinValue)
-            {
-                return 10;
-            }
-
-            if (number < 0)
-            {
-                number = -number;
-            }
-
-            int digits = 1;
-
-            while ((number /= 10) != 0)
-            {
-                ++digits;
-            }
-
-            return digits;
-        }
-    }
-
-    /// <param name="number">The numerical value to count the digits of.</param>
-    extension(long number)
-    {
-        /// <summary>
-        /// Counts the number of digits in the numerical value.
-        /// </summary>
-        /// <returns>The number of digits in the numerical value, returned as an integer.</returns>
-        public int CountNumberOfDigits()
-        {
-            // long.MinValue cannot be safely negated (would overflow); it has 19 digits.
-            if (number == long.MinValue)
-            {
-                return 19;
-            }
-
-            if (number < 0)
-            {
-                number = -number;
-            }
-
-            int digits = 1;
-
-            while ((number /= 10) != 0)
-            {
-                ++digits;
-            }
-
-            return digits;
-        }
-    }
-
-    /// <param name="number">The numerical value to count the digits of.</param>
-    extension(double number)
-    {
-        /// <summary>
-        /// Counts the number of digits in the numerical value.
-        /// </summary>
-        /// <returns>The number of digits in the numerical value, returned as a double precision floating point number; returns -1 if the value is <see cref="double.NaN"/> or <see cref="double.PositiveInfinity"/>.</returns>
-        public int CountNumberOfDigits()
-        {
-            if (double.IsNaN(number))
-            {
-                return -1;
-            }
-
-            if (number < 0.0 || (number == 0.0 && 1.0 / number < 0.0))
-            {
-                number = -number;
-            }
-
-            if (double.IsPositiveInfinity(number))
-            {
-                return -1;
-            }
-
-            int digits = 1;
-
-            while ((number /= 10.0) != 0.0)
-            {
-                ++digits;
-            }
-
-            return digits;
-        }
-    }
-#endif
 }

--- a/DotExtensions/System/Numbers/IncrementedNumberRange.cs
+++ b/DotExtensions/System/Numbers/IncrementedNumberRange.cs
@@ -22,9 +22,7 @@
        SOFTWARE.
    */
 
-#if NET8_0_OR_GREATER
 using System.Numerics;
-#endif
 
 namespace DotExtensions.Numbers;
 
@@ -33,7 +31,6 @@ namespace DotExtensions.Numbers;
 /// </summary>
 public static class IncrementedNumberRange
 {
-#if NET8_0_OR_GREATER
     /// <param name="source">The list of numbers to check.</param>
     /// <typeparam name="TNumber">The type that represents the numeric class or struct used for manipulating numbers.</typeparam>
     extension<TNumber>(IList<TNumber> source) where TNumber : INumber<TNumber>
@@ -103,69 +100,4 @@ public static class IncrementedNumberRange
             return true;
         }
     }
-#else
-    /// <param name="source">The list of numbers to check.</param>
-    extension(IList<int> source)
-    {
-        /// <summary>
-        /// Determines if an expected amount starting from the first number in the list increments a list of numbers.
-        /// </summary>
-        /// <param name="expectedIncrement">The amount each number is expected to be incremented by.</param>
-        /// <returns>True if each number in the list of numbers is incremented by the expected amount from the first number onwards, false otherwise.</returns>
-        public bool IsIncrementedNumberRange(int expectedIncrement)
-        {
-            int expectedNumber = source[0];
-
-            for (int index = 0; index < source.Count; index++)
-            {
-                int actual = source[index];
-
-                if (index > 0)
-                    expectedNumber += expectedIncrement;
-
-                if (expectedNumber != actual)
-                    return false;
-            }
-
-            return true;
-        }
-    }
-
-    /// <param name="source">The sequence of numbers to check.</param>
-    extension(IEnumerable<int> source)
-    {
-        /// <summary>
-        /// Determines if an expected amount starting from the first number in the sequence increments a sequence of numbers.
-        /// </summary>
-        /// <param name="expectedIncrement">The amount each number is expected to be incremented by.</param>
-        /// <returns>True if each number in the sequence of numbers is incremented by the expected amount from the first number onwards, false otherwise.</returns>
-        public bool IsIncrementedNumberRange(int expectedIncrement)
-        {
-            if (source is IList<int> list)
-                return list.IsIncrementedNumberRange(expectedIncrement);
-
-            bool foundFirstNumber = false;
-
-            int expectedNumber = 0;
-
-            foreach (int actual in source)
-            {
-                if (foundFirstNumber == false)
-                {
-                    expectedNumber = actual;
-                    foundFirstNumber = true;
-                }
-                else
-                {
-                    expectedNumber += expectedIncrement;
-                }
-
-                if (expectedNumber != actual)
-                    return false;
-            }
-
-            return true;
-        }
-    }
-#endif
 }

--- a/DotExtensions/System/Numbers/NumberToTNumber.cs
+++ b/DotExtensions/System/Numbers/NumberToTNumber.cs
@@ -22,7 +22,6 @@
        SOFTWARE.
    */
 
-#if NET8_0_OR_GREATER
 using System.Numerics;
 
 namespace DotExtensions.Numbers;
@@ -61,4 +60,3 @@ public static class NumberToTNumber
             => TDestinationNumber.Parse(number.ToString(), NumberFormatInfo.CurrentInfo);
     }
 }
-#endif

--- a/DotExtensions/System/Strings/Cases/CapitalizationExtensions.cs
+++ b/DotExtensions/System/Strings/Cases/CapitalizationExtensions.cs
@@ -73,9 +73,7 @@ public static class CapitalizationExtensions
                 if (index == -1)
                     throw new ArgumentException(
                         Resources.Exceptions_Indices_IndexOutOfRange.Replace("{0}", index.ToString("N", CultureInfo.CurrentCulture)
-#if NET8_0_OR_GREATER
                             , StringComparison.Ordinal
-#endif
                         ), nameof(indices));
                     
                 if(index >= str.Length)

--- a/README.md
+++ b/README.md
@@ -37,14 +37,11 @@ DotExtensions can be installed via the .NET SDK CLI, Nuget via your IDE or code 
 
 ### Compatibility
 DotExtensions supports:
-* .NET Standard 2.0 (Limited Support)
-* .NET 8
-* .NET 9
 * .NET 10
 
 However, it is important to note that not all features may be supported by all TFMs. 
 
-**Note for DateOnly**: Though DateOnly was originally part of .NET 6, this library's DateOnly extension methods are only supported for .NET 8 and newer .NET users since we don't target .NET 6 as a TFM due to being out of support.
+**Note for DateOnly**: Though DateOnly was originally part of .NET 6, this library's DateOnly extension methods require .NET 10.
 
 ## How to Build the code
 Please see [Building.md](https://github.com/alastairlundy/DotExtensions/blob/main/docs/Building.md).

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -6,9 +6,6 @@ DotExtensions requires the latest .NET release SDK to be installed to target all
 Currently, the required .NET SDK is .NET 10.
 
 The current build targets include:
-* .NET Standard 2.0
-* .NET 8
-* .NET 9
 * .NET 10
 
 Any version of the .NET 10 SDK can be used, but using the latest version is preferred.


### PR DESCRIPTION
All projects now target **net10.0 only** -- drops .NET Standard 2.0, .NET 8, and .NET 9.

Removes ~280 lines of conditional compilation (`#if NET8_0_OR_GREATER` / `#else` fallback code) and netstandard2.0-only package dependencies (Microsoft.Bcl.Memory, System.IO.FileSystem.AccessControl, System.Memory).

Multi-targeting, dead fallback paths, and outdated docs all cleaned up in one pass.

### Validation

- `dotnet build -c Release` -- 0 errors, 0 new warnings
- `dotnet test -c Release` -- 424/424 passed

---

Co-Authored by Copilot App using DeepSeek V4 Flash