### PR TITLE
Add Span<char>.RemoveAll tests and benchmarks

### DIFF
--- a/DotExtensions.AotTests/Program.cs
+++ b/DotExtensions.AotTests/Program.cs
@@ -40,4 +40,20 @@ int newLength = charSpan.RemoveAll("world");
 Console.WriteLine($"charSpan new length => {newLength}");
 Console.WriteLine($"charSpan contents => {charSpan[..newLength].ToString()}");
 
+// Value not found (short-circuit path)
+{
+    char[] a = "hi".ToCharArray();
+    Span<char> s = a.AsSpan();
+    int n = s.RemoveAll("xyz");
+    Console.WriteLine($"RemoveAll short-circuit => {n}");
+}
+
+// OrdinalIgnoreCase comparison path
+{
+    char[] a = "ABCabc".ToCharArray();
+    Span<char> s = a.AsSpan();
+    int n = s.RemoveAll("abc", StringComparison.OrdinalIgnoreCase);
+    Console.WriteLine($"RemoveAll OrdinalIgnoreCase => {a[..n].ToString()}");
+}
+
 Console.WriteLine(Resources.DotExtensions_AoT_Messages_Outro);

--- a/DotExtensions.Benchmarking/Benchmarks/Memory/SpanCharRemoveExtensionsBenchmarks.cs
+++ b/DotExtensions.Benchmarking/Benchmarks/Memory/SpanCharRemoveExtensionsBenchmarks.cs
@@ -1,0 +1,72 @@
+/*
+        MIT License
+
+       Copyright (c) 2026 Alastair Lundy
+
+       Permission is hereby granted, free of charge, to any person obtaining a copy
+       of this software and associated documentation files (the "Software"), to deal
+       in the Software without restriction, including without limitation the rights
+       to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+       copies of the Software, and to permit persons to whom the Software is
+       furnished to do so, subject to the following conditions:
+
+       The above copyright notice and this permission notice shall be included in all
+       copies or substantial portions of the Software.
+
+       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+       IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+       FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+       AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+       LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+       OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+       SOFTWARE.
+    */
+
+using System;
+using System.Linq;
+using DotExtensions.Benchmarking;
+using DotExtensions.Memory.Spans;
+
+namespace DotExtensions.Benchmarking.Benchmarks.Memory;
+
+/// <summary>
+/// Benchmark for <see cref="SpanCharRemoveExtensions"/> across three input sizes
+/// (short 16, medium 256, long 4096 chars).
+/// </summary>
+/// <remarks>
+/// Inputs are ASCII-only to avoid culture-specific flakiness. The source is
+/// copied to a pre-allocated scratch buffer before each invocation to avoid
+/// state pollution from in-place mutation.
+/// </remarks>
+[Config(typeof(FastBenchConfig))]
+[MemoryDiagnoser]
+[CsvMeasurementsExporter]
+[BenchmarkCategory("Short")]
+public class SpanCharRemoveExtensionsBenchmarks
+{
+    private const string Needle = "ab";
+
+    private char[] _source = [];
+    private char[] _scratch = [];
+
+    /// <summary>Source string length. Cycle is "abcd" (4 chars) so <see cref="N"/> must be a multiple of 4.</summary>
+    [Params(16, 256, 4096)]
+    public int N;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        const int cycleLength = 4;
+        int repeats = N / cycleLength;
+        _source = string.Concat(Enumerable.Repeat("abcd", repeats)).ToCharArray();
+        _scratch = GC.AllocateUninitializedArray<char>(N);
+    }
+
+    [Benchmark]
+    public int RemoveAll_ShortMediumLong()
+    {
+        _source.AsSpan().CopyTo(_scratch.AsSpan());
+        Span<char> span = _scratch.AsSpan();
+        return span.RemoveAll(Needle.AsSpan(), StringComparison.Ordinal);
+    }
+}

--- a/DotExtensions.Benchmarking/DotExtensions.Benchmarking.csproj
+++ b/DotExtensions.Benchmarking/DotExtensions.Benchmarking.csproj
@@ -16,5 +16,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DotExtensions\DotExtensions.csproj" />
+    <ProjectReference Include="..\DotExtensions.Memory\DotExtensions.Memory.csproj" />
   </ItemGroup>
 </Project>

--- a/DotExtensions.Tests/DotExtensions.Tests.csproj
+++ b/DotExtensions.Tests/DotExtensions.Tests.csproj
@@ -22,5 +22,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DotExtensions\DotExtensions.csproj" />
+    <ProjectReference Include="..\DotExtensions.Memory\DotExtensions.Memory.csproj" />
   </ItemGroup>
 </Project>

--- a/DotExtensions.Tests/Memory/SpanCharRemoveExtensionsTests.cs
+++ b/DotExtensions.Tests/Memory/SpanCharRemoveExtensionsTests.cs
@@ -1,0 +1,105 @@
+/*
+        MIT License
+
+       Copyright (c) 2026 Alastair Lundy
+
+       Permission is hereby granted, free of charge, to any person obtaining a copy
+       of this software and associated documentation files (the "Software"), to deal
+       in the Software without restriction, including without limitation the rights
+       to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+       copies of the Software, and to permit persons to whom the Software is
+       furnished to do so, subject to the following conditions:
+
+       The above copyright notice and this permission notice shall be included in all
+       copies or substantial portions of the Software.
+
+       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+       IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+       FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+       AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+       LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+       OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+       SOFTWARE.
+    */
+
+using System;
+using DotExtensions.Memory.Spans;
+
+namespace DotExtensions.Tests.Memory;
+
+public class SpanCharRemoveExtensionsTests
+{
+    [Test]
+    [Arguments("hello world", "xyz")]
+    [Arguments("abc", "abcdef")]
+    public async Task RemoveAll_ValueNotFound_ReturnsOriginalLength(string input, string value)
+    {
+        char[] chars = input.ToCharArray();
+        Span<char> source = chars.AsSpan();
+
+        int newLength = source.RemoveAll(value.AsSpan(), StringComparison.Ordinal);
+        string result = source[..newLength].ToString();
+
+        await Assert.That(newLength).IsEqualTo(input.Length);
+        await Assert.That(result).IsEqualTo(input);
+    }
+
+    [Test]
+    [Arguments("hello world", "world", "hello ")]
+    [Arguments("hello world", "hello", " world")]
+    [Arguments("abcXYZdef", "XYZ", "abcdef")]
+    [Arguments("aaa", "a", "")]
+    [Arguments("abcabc", "abc", "")]
+    public async Task RemoveAll_SingleOccurrence_RemovesCorrectly(string input, string value, string expected)
+    {
+        char[] chars = input.ToCharArray();
+        Span<char> source = chars.AsSpan();
+
+        int newLength = source.RemoveAll(value.AsSpan(), StringComparison.Ordinal);
+        string result = source[..newLength].ToString();
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("ababab", "ab", "")]
+    [Arguments("aXbXcXd", "X", "abcd")]
+    [Arguments("fooXXbarXXbaz", "XX", "foobarbaz")]
+    public async Task RemoveAll_MultipleOccurrences_RemovesAll(string input, string value, string expected)
+    {
+        char[] chars = input.ToCharArray();
+        Span<char> source = chars.AsSpan();
+
+        int newLength = source.RemoveAll(value.AsSpan(), StringComparison.Ordinal);
+        string result = source[..newLength].ToString();
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("Hello World", "hello", StringComparison.OrdinalIgnoreCase, " World")]
+    [Arguments("ABCABC", "abc", StringComparison.OrdinalIgnoreCase, "")]
+    public async Task RemoveAll_CaseInsensitiveComparison_RemovesCorrectly(
+        string input, string value, StringComparison comparison, string expected)
+    {
+        char[] chars = input.ToCharArray();
+        Span<char> source = chars.AsSpan();
+
+        int newLength = source.RemoveAll(value.AsSpan(), comparison);
+        string result = source[..newLength].ToString();
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task RemoveAll_EmptyValue_ThrowsArgumentException()
+    {
+        char[] chars = "hello".ToCharArray();
+
+        await Assert.That(() =>
+        {
+            Span<char> s = chars.AsSpan();
+            return s.RemoveAll(ReadOnlySpan<char>.Empty, StringComparison.Ordinal);
+        }).Throws<ArgumentException>();
+    }
+}

--- a/DotExtensions.Tests/Memory/SpanCharRemoveExtensionsTests.cs
+++ b/DotExtensions.Tests/Memory/SpanCharRemoveExtensionsTests.cs
@@ -48,8 +48,7 @@ public class SpanCharRemoveExtensionsTests
     [Arguments("hello world", "world", "hello ")]
     [Arguments("hello world", "hello", " world")]
     [Arguments("abcXYZdef", "XYZ", "abcdef")]
-    [Arguments("aaa", "a", "")]
-    [Arguments("abcabc", "abc", "")]
+    [Arguments("abcdef", "bcd", "aef")]
     public async Task RemoveAll_SingleOccurrence_RemovesCorrectly(string input, string value, string expected)
     {
         char[] chars = input.ToCharArray();
@@ -65,6 +64,8 @@ public class SpanCharRemoveExtensionsTests
     [Arguments("ababab", "ab", "")]
     [Arguments("aXbXcXd", "X", "abcd")]
     [Arguments("fooXXbarXXbaz", "XX", "foobarbaz")]
+    [Arguments("aaa", "a", "")]
+    [Arguments("abcabc", "abc", "")]
     public async Task RemoveAll_MultipleOccurrences_RemovesAll(string input, string value, string expected)
     {
         char[] chars = input.ToCharArray();
@@ -89,6 +90,20 @@ public class SpanCharRemoveExtensionsTests
         string result = source[..newLength].ToString();
 
         await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("", "abc")]
+    public async Task RemoveAll_EmptySource_ReturnsZero(string input, string value)
+    {
+        char[] chars = input.ToCharArray();
+        Span<char> source = chars.AsSpan();
+
+        int newLength = source.RemoveAll(value.AsSpan(), StringComparison.Ordinal);
+        string result = source[..newLength].ToString();
+
+        await Assert.That(newLength).IsEqualTo(0);
+        await Assert.That(result).IsEqualTo("");
     }
 
     [Test]


### PR DESCRIPTION
## What

Adds the remaining additive tickets (7 and 8) from the v10 performance improvements backlog for `Span<char>.RemoveAll` — public API tests, AOT runtime coverage, and a BDN benchmark.

## Changes

- **`DotExtensions.Tests/Memory/SpanCharRemoveExtensionsTests.cs`** — TUnit tests covering value-not-found, single/multiple removal, case-insensitive comparison, and empty-value validation
- **`DotExtensions.AotTests/Program.cs`** — Extended with short-circuit and `OrdinalIgnoreCase` AOT runtime coverage
- **`DotExtensions.Benchmarking/Benchmarks/Memory/SpanCharRemoveExtensionsBenchmarks.cs`** — BDN benchmark across short (16), medium (256), and long (4096) inputs, with pre-allocated scratch buffer for clean in-place mutation measurements
- **Project references** — Added `DotExtensions.Memory` to both `DotExtensions.Tests` and `DotExtensions.Benchmarking`

## Verification

- `dotnet build -c Release` — 0 errors
- `dotnet test -c Release` — all 437 tests pass
- BDN benchmark runs successfully (zero allocations on ordinal path, as expected)

Co-Authored by Copilot App (using DeepSeek V4 Flash)